### PR TITLE
Added back DrawScatter and DrawHeatmap

### DIFF
--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -1,121 +1,155 @@
-#' Plot a scatter plot of a single cell vs. a single reference cell/sample
+#' Plot expression of a cell versus a reference cell/sample
 #'
-#' @param sc_data Similar to SinlgeR test input, a numeric matrix of single-cell expression values (usually
-#' log-transformed or otherwise variance-stabilized), where rows are genes and columns are cells.
+#' @param sc.data Numeric matrix of single-cell expression values (usually log-transformed
+#' or otherwise variance-stabilized), where rows are genes and columns are cells.
 #' Alternatively, a \linkS4class{SingleCellExperiment} object containing such a matrix.
-#' @param cell_id a number indicating which single cell to use.
+#' @param sc.id Integer scalar specifying the index of the target cell to use.
 #' Alternatively, the name of the cell.
-#' @param refdata Similar to SinlgeR training input, a numeric matrix of expression values. 
+#' @param train.data Numeric matrix of reference dataset expression values (usually log-transformed
+#' or otherwise variance-stabilized), where rows are genes and columns are cells.
 #' Alternatively, a \linkS4class{SingleCellExperiment} object containing such a matrix.
-#' This should have the same rows as or a subset of the rows in \code{test}.
-#' @param sample_id a number of the sample to use
-#' @param assay.type An integer scalar or string specifying the assay of \code{sc_data} or \code{refdata} containing the relevant expression matrix,
-#' if \code{sc_data} or \code{refdata} is a \linkS4class{SingleCellExperiment} object.
-#'
+#' @param train.id Integer scalar specifying the reference cell/sample to use.
+#' @param assay.type.sc Integer scalar or Character specifying the assay of \code{sc.data} containing the relevant assay if provided as a \linkS4class{SingleCellExperiment}.
+#' @param assay.type.train Integer scalar or Character specifying the assay of \code{train.data} containing the relevant assay if provided as a \linkS4class{SingleCellExperiment}.
+#' if \code{sc.data} or \code{train.data} is a \linkS4class{SingleCellExperiment} object.
 #' @return a gpplot scatterplot of the expression of indidivual genes, with linear regression and Spearman pariwaise correlation coefficient
+#' @details This function allows a user to manually check how cells compare to reference cells of the same type or of a different type.
+#' @author Daniel Bunis, based on code by Dvir Aran.
+#' @examples
+#' ###########################################
+#' ## Mocking up some example training data ##
+#' ###########################################
+#'
+#' Ngroups <- 5
+#' Ngenes <- 1000
+#' means <- matrix(rnorm(Ngenes*Ngroups), nrow=Ngenes)
+#' means[1:900,] <- 0
+#' colnames(means) <- LETTERS[1:5]
+#'
+#' N <- 100
+#' g <- sample(LETTERS[1:5], N, replace=TRUE)
+#' train.data <- SingleCellExperiment(
+#'     list(counts=matrix(rpois(1000*N, lambda=2^means[,g]), ncol=N)),
+#'     colData=DataFrame(label=g)
+#' )
+#' rownames(train.data) <- sprintf("GENE_%s", seq_len(nrow(train.data)))
+#'
+#' ##################################################
+#' ## Mocking up some test data for classification ##
+#' ##################################################
+#'
+#' N <- 100
+#' g <- sample(LETTERS[1:5], N, replace=TRUE)
+#' sc.data <- SingleCellExperiment(
+#'     list(counts=matrix(rpois(1000*N, lambda=2^means[,g]), ncol=N)),
+#'     colData=DataFrame(label=g)
+#' )
+#' rownames(sc.data) <- sprintf("GENE_%s", seq_len(nrow(sc.data)))
+#' 
+#' #####################
+#' ## Running SingleR ##
+#' #####################
+#' 
+#' pred <- SingleR(sc.data, train.data, labels=train.data$label)
+#' table(predicted=pred$labels, truth=g)
+#' 
+#' ##### Check if cell#1 resembles reference-set cells of the same type
+#' # Identify reference cells of the same type as cell#1
+#'   #This cell is type...
+#'   pred$labels[1]
+#' ref.sameType.as1 <- grep(pred$labels[1], train.data$label)
+#' 
+#' # Compare expression of target cell to reference cells of the same type
+#' plotCellVsReference(sc.data, sc.id = 1,
+#'                     train.data, train.id = ref.sameType.as1[1])
+#' 
+#' # Compare expression of target cell to reference cells of a different type
+#' ref.diffType.as1 <- seq_along(train.data$label)[-ref.sameType.as1]
+#' plotCellVsReference(sc.data, sc.id = 1,
+#'                     train.data, train.id = ref.diffType.as1[1])
 #' 
 #' @export
 #' @importFrom ggplot2 ggplot geom_point geom_smooth theme xlab ylab ggtitle theme_classic
-SingleR.DrawScatter = function(sc_data, cell_id, refdata,sample_id, assay.type = 1) {
-  if (is(sc_data, "SingleCellExperiment")) {
-    sc_data <- assay(sc_data, assay.type)
-  }
-  if (is(refdata, "SingleCellExperiment")) {
-    refdata <- assay(refdata, assay.type)
-  }
-  if (is(refdata, "list")) {
-    refdata <- refdata$data
-  }
-  rownames(sc_data) = tolower(rownames(sc_data))
-  rownames(refdata) = tolower(rownames(refdata))
-  A = intersect(rownames(sc_data),rownames(refdata))
-  df = data.frame(sc_data[A,cell_id],refdata[A,sample_id])
-  colnames(df) = c('x','y')
-  ggplot(df,aes(x=x, y=y)) + geom_point(size=0.5,alpha=0.5,color='blue') +
-    geom_smooth(method='lm',color='red')+
-    theme(legend.position="none") + xlab('Single cell') + ylab('Reference sample') +
-    ggtitle(paste('R =', round(1000*cor(df$x,df$y,method='spearman',use='pairwise'))/1000)) + 
-    theme_classic()
+#' @importFrom SummarizedExperiment assay
+#' @importClassesFrom SingleCellExperiment SingleCellExperiment
+#' @importFrom methods is
+plotCellVsReference <- function(sc.data, sc.id, train.data,train.id, assay.type.sc = 1, assay.type.train = 1) {
+    if (is(sc.data, "SingleCellExperiment")) {
+        sc.data <- assay(sc.data, assay.type.sc)
+    }
+    if (is(train.data, "SingleCellExperiment")) {
+        train.data <- assay(train.data, assay.type.train)
+    }
+    if (is(train.data, "list")) {
+        train.data <- train.data$data
+    }
+    rownames(sc.data) <- tolower(rownames(sc.data))
+    rownames(train.data) <- tolower(rownames(train.data))
+    A <- intersect(rownames(sc.data),rownames(train.data))
+    df <- data.frame(sc.data[A,sc.id],train.data[A,train.id])
+    colnames(df) <- c('x','y')
+    ggplot(df,aes(x=x, y=y)) + geom_point(size=0.5,alpha=0.5,color='blue') +
+        geom_smooth(method='lm',color='red')+
+        theme(legend.position="none") + xlab('Single cell') + ylab('Reference sample') +
+        ggtitle(paste('R =', round(1000*cor(df$x,df$y,method='spearman',use='pairwise'))/1000)) + 
+        theme_classic()
 }
 
-#' Plot a heatmap of the scores for all the single cells
+#' Plot a heatmap of the scoring of cells
 #'
-#' @param SingleR.results the output from a run of the SingleR/classifySingleR
-#' @param cells.use single cells to present, if NULL all single cells presented
-#' @param types.use cell types to present, if NULL all cell types presented
-#' @param clusters a clustering to present as annotation in the heatmap
-#' @param top.n number of cell types to presents. Default is 40. This can have an effect on the clustering which is performed only on the cell types presented.
-#' @param normalize if TRUE scores are normalized to a 0-1 scale.
-#' @param order.by.clusters if TRUE columns are ordered by the input clusters, and are not clustered again
-#' @param cells_order an input order for the column
-#' @param silent if TRUE do not draw the plot
+#' @param SingleR.results DataFrame output from a run of \code{SingleR()} or \code{classifySingleR()}
+#' @param cells.use Integer or Character vector of single cells to present. If NULL, all cells are presented.
+#' @param labels.use Character vector indicating what cell types to present. If NULL, all cell types are presented.
+#' @param clustering Character vector of Factor representing cell clustering to be present as annotation in the heatmap.
+#' @param max.label Integer scalar representing the number of cell types to present. Default is 40. This can have an effect on the clustering which is performed only on the cell types presented.
+#' @param normalize Logical that sets if scores are normalized to a 0-1 scale.  Default is TRUE.
+#' @param order.by.clusters Logical that sets if cells are ordered by the input clusters and not clustered based on scoring.  Default is FALSE. Takes precedence over \code{cells.order} input.
+#' @param cells.order Integer vector with length equal to the number of cells in the heatmap. Sets the ordering of cells/columns of the heatmap. Turns off clustering of columns based on scoring.
+#' @param silent Logical that sets whether the plot drawn.
+#' @param ... Additional parameters for heatmap control passed to \code{pheatmap()}
+#' @export
 #' @importFrom pheatmap pheatmap
-SingleR.DrawHeatmap = function(SingleR.results,cells.use = NULL, types.use = NULL,
-                               clusters=NULL,top.n=40,normalize=TRUE,
-                               order.by.clusters=FALSE,cells_order=NULL,silent=FALSE,
-                               fontsize_row=9,...) {
-  scores = SingleR.results$scores
-  if (!is.null(cells.use)) {
-    scores = scores[cells.use,]
-  }
-  if (!is.null(types.use)) {
-    scores = scores[,types.use]
-  }
-  
-  m = apply(t(scale(t(scores))),2,max)
-  
-  thres = sort(m,decreasing=TRUE)[min(top.n,length(m))]
-  
-  data = as.matrix(scores)
-  
-  if (normalize==TRUE) {
-    mmax = rowMaxs(data)
-    mmin = rowMins(data)
-    data = (data-mmin)/(mmax-mmin)
-    data = data^3
-  }
-  data = data[,m>(thres-1e-6)]
-  
-  data = t(data)
-  
-  if (!is.null(clusters)) {
-    clusters = as.data.frame(clusters)
-    colnames(clusters) = 'Clusters'
-    rownames(clusters) = colnames(data)
-    
-  }
-  additional_params = list(...)
-  if (is.null(additional_params$annotation_colors)) {
-    annotation_colors = NA
-  } else {
-    annotation_colors = additional_params$annotation_colors
-  }
-  clustering_method = 'ward.D2'
-  if (order.by.clusters==TRUE) {
-    data = data[,order(clusters$Clusters)]
-    clusters = clusters[order(clusters$Clusters),,drop=FALSE]
-    pheatmap::pheatmap(data,border_color=NA,show_colnames=FALSE,
-                       clustering_method=clustering_method,fontsize_row=fontsize_row,
-                       annotation_col = clusters,cluster_cols = FALSE,silent=silent, 
-                       annotation_colors=annotation_colors)
-  } else if (!is.null(cells_order)) {
-    data = data[,cells_order]
-    clusters = clusters[cells_order,,drop=FALSE]
-    pheatmap::pheatmap(data,border_color=NA,show_colnames=FALSE,
-                       clustering_method=clustering_method,fontsize_row=fontsize_row,
-                       annotation_col = clusters,cluster_cols = FALSE,silent=silent, 
-                       annotation_colors=annotation_colors)
-  } else {
-    if (!is.null(clusters)) {
-      pheatmap::pheatmap(data,border_color=NA,show_colnames=FALSE,
-                         clustering_method=clustering_method,fontsize_row=fontsize_row,
-                         annotation_col = clusters,silent=silent, 
-                         annotation_colors=annotation_colors)
-    } else {
-      pheatmap::pheatmap(data[,sample(ncol(data))],border_color=NA,show_colnames=FALSE,
-                         clustering_method=clustering_method,fontsize_row=fontsize_row,
-                         silent=silent, annotation_colors=annotation_colors)
-      
+plotScoreHeatmap <- function(SingleR.results, cells.use = NULL, labels.use = NULL,
+                             clusters=NULL, max.labels=40, normalize=TRUE,
+                             cells.order=NULL, order.by.clusters=FALSE, silent=FALSE,
+                             fontsize.row=9, ...) {
+    scores <- SingleR.results$scores
+    if (!is.null(cells.use)) {
+        scores <- scores[cells.use,]
     }
-  }
+    if (!is.null(labels.use)) {
+        scores <- scores[,labels.use]
+    }
+    m <- apply(t(scale(t(scores))),2,max)
+    thres <- sort(m,decreasing=TRUE)[min(max.label,length(m))]
+    data <- as.matrix(scores)
+    if (normalize==TRUE) {
+        mmax <- rowMaxs(data)
+        mmin <- rowMins(data)
+        data <- (data-mmin)/(mmax-mmin)
+        data <- data^3
+    }
+    data <- data[,m>(thres-1e-6)]
+    data <- t(data)
+    if (!is.null(clusters)) {
+        clusters <- as.data.frame(clusters)
+        colnames(clusters) <- 'Clusters'
+        rownames(clusters) <- colnames(data)
+    }
+    cluster_cols <- FALSE
+    if (order.by.clusters==TRUE) {
+        order <- order(clusters$Clusters)
+    } else if (!is.null(cells.order)){
+        order <- cells.order
+    } else {
+        order <- seq_len(ncol(args$mat))
+        cluster_cols <- TRUE
+    }
+    args <- list(mat = data[,order], border_color = NA, show_colnames = FALSE,
+                 clustering_method = 'ward.D2', fontsize_row = fontsize_row,
+                 silent = silent, cluster_cols = cluster_cols, ...)
+    if (!is.null(clusters)) {
+        args$annotation_col <- clusters[order,,drop=FALSE]
+    }
+    do.call(pheatmap::pheatmap, args)
 }

--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -60,19 +60,26 @@
 #' 
 #' # Compare expression of target cell to reference cells of the same type
 #' plotCellVsReference(sc.data, sc.id = 1,
-#'                     train.data, train.id = ref.sameType.as1[1])
+#'                     train.data, train.id = ref.sameType.as1[1],
+#'                     assay.type.sc = 'counts',
+#'                     assay.type.train = 'counts')
 #' 
 #' # Compare expression of target cell to reference cells of a different type
 #' ref.diffType.as1 <- seq_along(train.data$label)[-ref.sameType.as1]
 #' plotCellVsReference(sc.data, sc.id = 1,
-#'                     train.data, train.id = ref.diffType.as1[1])
+#'                     train.data, train.id = ref.diffType.as1[1],
+#'                     assay.type.sc = 'counts',
+#'                     assay.type.train = 'counts')
+#' ###
+#' ## Note: for this mock data, normalization has not been run, so we used
+#' #  the raw counts data here, but logcounts (default) is normally recommended.
 #' 
 #' @export
 #' @importFrom ggplot2 ggplot geom_point geom_smooth theme xlab ylab ggtitle theme_classic
 #' @importFrom SummarizedExperiment assay
 #' @importClassesFrom SingleCellExperiment SingleCellExperiment
 #' @importFrom methods is
-plotCellVsReference <- function(sc.data, sc.id, train.data,train.id, assay.type.sc = 1, assay.type.train = 1) {
+plotCellVsReference <- function(sc.data, sc.id, train.data,train.id, assay.type.sc = 'logcounts', assay.type.train = 'logcounts') {
     if (is(sc.data, "SingleCellExperiment")) {
         sc.data <- assay(sc.data, assay.type.sc)
     }

--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -101,7 +101,7 @@ plotCellVsReference <- function(sc.data, sc.id, train.data,train.id, assay.type.
 #' @param cells.use Integer or Character vector of single cells to present. If NULL, all cells are presented.
 #' @param labels.use Character vector indicating what cell types to present. If NULL, all cell types are presented.
 #' @param clustering Character vector of Factor representing cell clustering to be present as annotation in the heatmap.
-#' @param max.label Integer scalar representing the number of cell types to present. Default is 40. This can have an effect on the clustering which is performed only on the cell types presented.
+#' @param max.labels Integer scalar representing the number of cell types to present. Default is 40. This can have an effect on the clustering which is performed only on the cell types presented.
 #' @param normalize Logical that sets if scores are normalized to a 0-1 scale.  Default is TRUE.
 #' @param order.by.clusters Logical that sets if cells are ordered by the input clusters and not clustered based on scoring.  Default is FALSE. Takes precedence over \code{cells.order} input.
 #' @param cells.order Integer vector with length equal to the number of cells in the heatmap. Sets the ordering of cells/columns of the heatmap. Turns off clustering of columns based on scoring.
@@ -121,7 +121,7 @@ plotScoreHeatmap <- function(SingleR.results, cells.use = NULL, labels.use = NUL
         scores <- scores[,labels.use]
     }
     m <- apply(t(scale(t(scores))),2,max)
-    thres <- sort(m,decreasing=TRUE)[min(max.label,length(m))]
+    thres <- sort(m,decreasing=TRUE)[min(max.labels,length(m))]
     data <- as.matrix(scores)
     if (normalize==TRUE) {
         mmax <- rowMaxs(data)
@@ -142,11 +142,11 @@ plotScoreHeatmap <- function(SingleR.results, cells.use = NULL, labels.use = NUL
     } else if (!is.null(cells.order)){
         order <- cells.order
     } else {
-        order <- seq_len(ncol(args$mat))
+        order <- seq_len(ncol(data))
         cluster_cols <- TRUE
     }
     args <- list(mat = data[,order], border_color = NA, show_colnames = FALSE,
-                 clustering_method = 'ward.D2', fontsize_row = fontsize_row,
+                 clustering_method = 'ward.D2', fontsize_row = fontsize.row,
                  silent = silent, cluster_cols = cluster_cols, ...)
     if (!is.null(clusters)) {
         args$annotation_col <- clusters[order,,drop=FALSE]

--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -1,0 +1,121 @@
+#' Plot a scatter plot of a single cell vs. a single reference cell/sample
+#'
+#' @param sc_data Similar to SinlgeR test input, a numeric matrix of single-cell expression values (usually
+#' log-transformed or otherwise variance-stabilized), where rows are genes and columns are cells.
+#' Alternatively, a \linkS4class{SingleCellExperiment} object containing such a matrix.
+#' @param cell_id a number indicating which single cell to use.
+#' Alternatively, the name of the cell.
+#' @param refdata Similar to SinlgeR training input, a numeric matrix of expression values. 
+#' Alternatively, a \linkS4class{SingleCellExperiment} object containing such a matrix.
+#' This should have the same rows as or a subset of the rows in \code{test}.
+#' @param sample_id a number of the sample to use
+#' @param assay.type An integer scalar or string specifying the assay of \code{sc_data} or \code{refdata} containing the relevant expression matrix,
+#' if \code{sc_data} or \code{refdata} is a \linkS4class{SingleCellExperiment} object.
+#'
+#' @return a gpplot scatterplot of the expression of indidivual genes, with linear regression and Spearman pariwaise correlation coefficient
+#' 
+#' @export
+#' @importFrom ggplot2 ggplot geom_point geom_smooth theme xlab ylab ggtitle theme_classic
+SingleR.DrawScatter = function(sc_data, cell_id, refdata,sample_id, assay.type = 1) {
+  if (is(sc_data, "SingleCellExperiment")) {
+    sc_data <- assay(sc_data, assay.type)
+  }
+  if (is(refdata, "SingleCellExperiment")) {
+    refdata <- assay(refdata, assay.type)
+  }
+  if (is(refdata, "list")) {
+    refdata <- refdata$data
+  }
+  rownames(sc_data) = tolower(rownames(sc_data))
+  rownames(refdata) = tolower(rownames(refdata))
+  A = intersect(rownames(sc_data),rownames(refdata))
+  df = data.frame(sc_data[A,cell_id],refdata[A,sample_id])
+  colnames(df) = c('x','y')
+  ggplot(df,aes(x=x, y=y)) + geom_point(size=0.5,alpha=0.5,color='blue') +
+    geom_smooth(method='lm',color='red')+
+    theme(legend.position="none") + xlab('Single cell') + ylab('Reference sample') +
+    ggtitle(paste('R =', round(1000*cor(df$x,df$y,method='spearman',use='pairwise'))/1000)) + 
+    theme_classic()
+}
+
+#' Plot a heatmap of the scores for all the single cells
+#'
+#' @param SingleR.results the output from a run of the SingleR/classifySingleR
+#' @param cells.use single cells to present, if NULL all single cells presented
+#' @param types.use cell types to present, if NULL all cell types presented
+#' @param clusters a clustering to present as annotation in the heatmap
+#' @param top.n number of cell types to presents. Default is 40. This can have an effect on the clustering which is performed only on the cell types presented.
+#' @param normalize if TRUE scores are normalized to a 0-1 scale.
+#' @param order.by.clusters if TRUE columns are ordered by the input clusters, and are not clustered again
+#' @param cells_order an input order for the column
+#' @param silent if TRUE do not draw the plot
+#' @importFrom pheatmap pheatmap
+SingleR.DrawHeatmap = function(SingleR.results,cells.use = NULL, types.use = NULL,
+                               clusters=NULL,top.n=40,normalize=TRUE,
+                               order.by.clusters=FALSE,cells_order=NULL,silent=FALSE,
+                               fontsize_row=9,...) {
+  scores = SingleR.results$scores
+  if (!is.null(cells.use)) {
+    scores = scores[cells.use,]
+  }
+  if (!is.null(types.use)) {
+    scores = scores[,types.use]
+  }
+  
+  m = apply(t(scale(t(scores))),2,max)
+  
+  thres = sort(m,decreasing=TRUE)[min(top.n,length(m))]
+  
+  data = as.matrix(scores)
+  
+  if (normalize==TRUE) {
+    mmax = rowMaxs(data)
+    mmin = rowMins(data)
+    data = (data-mmin)/(mmax-mmin)
+    data = data^3
+  }
+  data = data[,m>(thres-1e-6)]
+  
+  data = t(data)
+  
+  if (!is.null(clusters)) {
+    clusters = as.data.frame(clusters)
+    colnames(clusters) = 'Clusters'
+    rownames(clusters) = colnames(data)
+    
+  }
+  additional_params = list(...)
+  if (is.null(additional_params$annotation_colors)) {
+    annotation_colors = NA
+  } else {
+    annotation_colors = additional_params$annotation_colors
+  }
+  clustering_method = 'ward.D2'
+  if (order.by.clusters==TRUE) {
+    data = data[,order(clusters$Clusters)]
+    clusters = clusters[order(clusters$Clusters),,drop=FALSE]
+    pheatmap::pheatmap(data,border_color=NA,show_colnames=FALSE,
+                       clustering_method=clustering_method,fontsize_row=fontsize_row,
+                       annotation_col = clusters,cluster_cols = FALSE,silent=silent, 
+                       annotation_colors=annotation_colors)
+  } else if (!is.null(cells_order)) {
+    data = data[,cells_order]
+    clusters = clusters[cells_order,,drop=FALSE]
+    pheatmap::pheatmap(data,border_color=NA,show_colnames=FALSE,
+                       clustering_method=clustering_method,fontsize_row=fontsize_row,
+                       annotation_col = clusters,cluster_cols = FALSE,silent=silent, 
+                       annotation_colors=annotation_colors)
+  } else {
+    if (!is.null(clusters)) {
+      pheatmap::pheatmap(data,border_color=NA,show_colnames=FALSE,
+                         clustering_method=clustering_method,fontsize_row=fontsize_row,
+                         annotation_col = clusters,silent=silent, 
+                         annotation_colors=annotation_colors)
+    } else {
+      pheatmap::pheatmap(data[,sample(ncol(data))],border_color=NA,show_colnames=FALSE,
+                         clustering_method=clustering_method,fontsize_row=fontsize_row,
+                         silent=silent, annotation_colors=annotation_colors)
+      
+    }
+  }
+}

--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -9,10 +9,9 @@
 #' or otherwise variance-stabilized), where rows are genes and columns are cells.
 #' Alternatively, a \linkS4class{SingleCellExperiment} object containing such a matrix.
 #' @param train.id Integer scalar specifying the reference cell/sample to use.
-#' @param assay.type.sc Integer scalar or Character specifying the assay of \code{sc.data} containing the relevant assay if provided as a \linkS4class{SingleCellExperiment}.
-#' @param assay.type.train Integer scalar or Character specifying the assay of \code{train.data} containing the relevant assay if provided as a \linkS4class{SingleCellExperiment}.
-#' if \code{sc.data} or \code{train.data} is a \linkS4class{SingleCellExperiment} object.
-#' @return a gpplot scatterplot of the expression of indidivual genes, with linear regression and Spearman pariwaise correlation coefficient
+#' @param assay.type.sc Integer scalar or Character specifying the assay of \code{sc.data} containing the relevant expression data.  Used if provided \code{sc.data} is a \linkS4class{SingleCellExperiment}.
+#' @param assay.type.train Integer scalar or Character specifying the assay of \code{train.data} containing the relevant expression data.  Used if provided \code{train.data} is a \linkS4class{SingleCellExperiment}.
+#' @return a gpplot scatterplot of the expression of individual genes, with linear regression and Spearman pairwise correlation coefficient added.
 #' @details This function allows a user to manually check how cells compare to reference cells of the same type or of a different type.
 #' @author Daniel Bunis, based on code by Dvir Aran.
 #' @examples

--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -112,9 +112,11 @@ plotScoreHeatmap <- function(SingleR.results, cells.use = NULL, labels.use = NUL
                              cells.order=NULL, order.by.clusters=FALSE, silent=FALSE,
                              fontsize.row=9, ...) {
     scores <- SingleR.results$scores
-    if (!is.null(cells.use)) {
-        scores <- scores[cells.use,]
+    rownames(scores) <- rownames(SingleR.results)
+    if(is.null(cells.use)){
+        cells.use <- seq_len(nrow(SingleR.results))
     }
+    scores <- scores[cells.use,]
     if (!is.null(labels.use)) {
         scores <- scores[,labels.use]
     }
@@ -130,9 +132,8 @@ plotScoreHeatmap <- function(SingleR.results, cells.use = NULL, labels.use = NUL
     data <- data[,m>(thres-1e-6)]
     data <- t(data)
     if (!is.null(clusters)) {
-        clusters <- as.data.frame(clusters)
-        colnames(clusters) <- 'Clusters'
-        rownames(clusters) <- colnames(data)
+        names(clusters) <- rownames(SingleR.results)
+        clusters <- data.frame(Clusters = clusters[colnames(data)], row.names = colnames(data))
     }
     cluster_cols <- FALSE
     if (order.by.clusters==TRUE) {

--- a/R/SingleR.visualizations.R
+++ b/R/SingleR.visualizations.R
@@ -86,12 +86,11 @@ plotCellVsReference <- function(sc.data, sc.id, train.data,train.id, assay.type.
     rownames(sc.data) <- tolower(rownames(sc.data))
     rownames(train.data) <- tolower(rownames(train.data))
     A <- intersect(rownames(sc.data),rownames(train.data))
-    df <- data.frame(sc.data[A,sc.id],train.data[A,train.id])
-    colnames(df) <- c('x','y')
+    df <- data.frame(x = sc.data[A,sc.id], y = train.data[A,train.id])
     ggplot(df,aes(x=x, y=y)) + geom_point(size=0.5,alpha=0.5,color='blue') +
         geom_smooth(method='lm',color='red')+
         theme(legend.position="none") + xlab('Single cell') + ylab('Reference sample') +
-        ggtitle(paste('R =', round(1000*cor(df$x,df$y,method='spearman',use='pairwise'))/1000)) + 
+        ggtitle(paste('R =', format(round(cor(df$x,df$y,method='spearman',use='pairwise'), 3), 3))) + 
         theme_classic()
 }
 


### PR DESCRIPTION
Copied code over from dviraran/SingleR/master/R/SingleR.Plotting.R, modified DrawScatter and DrawHeatmap code to work with newer data structures, and edited their documentation to reflect the new changes.

Additional notes from Dan:
-To see comparison of Dvir's code and mine, your can check this commit in my SingleR-Vingette repo: https://github.com/dtm2451/SingleR-Vignette/commit/0089065efcf124ec3006943fd25baacdddcb33ea
-DrawScatter compares a cell to an individual cell/sample from the reference dataset.  The old method involved picking an index # from a single table full of all the samples.  In the new SingleR.train structure, data for cells/samples of the same type are stored separately so the previous indexing method does not work.
My current fix: require provision of the original counts/logcounts dataframe that was used to generate the training.
Potential alternative: Utilize the trained data, and make the index refer to which of the trained cells of a given type should be used
-DrawHeatmap works with little updating required.  I mainly just changed T/F to TRUE/FALSE here and pointed the pheatmap calls explicitly to the pheatmap package in case it has not already been loaded into the namespace.
-DrawBoxPlot update is in progress
-The two tsne plotting functions that previously existed in SingleR will implemented with DittoSeq