### PR TITLE
Doc updates

### DIFF
--- a/vignettes/SingleR.Rmd
+++ b/vignettes/SingleR.Rmd
@@ -1,6 +1,9 @@
 ---
 title: Using SingleR to annotate single-cell RNA-seq data
-author: Aaron Lun, Jared Andrews
+author: 
+- name: Aaron Lun 
+- name: Jared M. Andrews
+  affiliation: Washington University in St. Louis, School of Medicine, St. Louis, MO, USA
 date: "Revised: 8 October 2019"
 output:
   BiocStyle::html_document:

--- a/vignettes/SingleR.Rmd
+++ b/vignettes/SingleR.Rmd
@@ -59,9 +59,9 @@ We then compute log-normalized expression values.
 ```{r}
 library(scater)
 sceM <- sceM[,!is.na(sceM$label)]
-sceM <- normalize(sceM)
+sceM <- logNormCounts(sceM)
 sceG <- sceG[,colSums(counts(sceG)) > 0]
-sceG <- normalize(sceG)
+sceG <- logNormCounts(sceG)
 ```
 
 The @muraro2016singlecell dataset contains labels so we will use this as our reference dataset.
@@ -149,6 +149,7 @@ It creates a scatter plot of the chosen cell's expression profile against the sp
 ```{r}
 # Get first cell label from our predictions - "acinar" in this case.
 pred$labels[1]
+
 # Get all cells in reference set with "acinar" label and plot against the first in this list.
 same.type <- grep(pred$labels[1], sceM$label)
 plotCellVsReference(sceG, test.id = 1, ref = sceM, ref.id = same.type[1])
@@ -195,7 +196,7 @@ hESCs <- hESCs[,1:100]
 common <- intersect(rownames(hESCs), rownames(hpca$data))
 hESCs <- hESCs[common,]
 hESCs <- hESCs[,colSums(counts(hESCs)) > 0]
-hESCs <- normalize(hESCs)
+hESCs <- logNormCounts(hESCs)
 hpca$data <- hpca$data[common,]
 
 # Annotate the samples:

--- a/vignettes/SingleR.Rmd
+++ b/vignettes/SingleR.Rmd
@@ -54,14 +54,14 @@ sceG <- sceG[common,]
 ```
 
 One should normally do quality control at this point, but for brevity's sake, we will just remove the empty or unlabelled libraries here.
-We then compute log-normalized expression values.
+We then compute log-normalized expression values, ignoring spike-ins in the Grun dataset by setting `use_altexps=FALSE`.
 
 ```{r}
 library(scater)
 sceM <- sceM[,!is.na(sceM$label)]
 sceM <- logNormCounts(sceM)
 sceG <- sceG[,colSums(counts(sceG)) > 0]
-sceG <- logNormCounts(sceG)
+sceG <- logNormCounts(sceG, use_altexps=FALSE)
 ```
 
 The @muraro2016singlecell dataset contains labels so we will use this as our reference dataset.

--- a/vignettes/SingleR.Rmd
+++ b/vignettes/SingleR.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Using SingleR to annotate single-cell RNA-seq data
-author: Aaron Lun
-date: "Revised: 17 October 2018"
+author: Aaron Lun, Jared Andrews
+date: "Revised: 8 October 2019"
 output:
   BiocStyle::html_document:
     toc_float: true
@@ -54,7 +54,7 @@ sceG <- sceG[common,]
 ```
 
 One should normally do quality control at this point, but for brevity's sake, we will just remove the empty or unlabelled libraries here.
-We then compute log-normalized expression values^[This is only necessary for the marker gene detection step.].
+We then compute log-normalized expression values.
 
 ```{r}
 library(scater)
@@ -141,10 +141,41 @@ pred3 <- SingleR(test=sceG, ref=sceM, labels=sceM$label, genes=label.markers)
 table(pred$labels, pred3$labels)
 ```
 
+## Visualization
+`r Biocpkg("SingleR")` has a few basic, yet powerful visualizations available. 
+We can use `plotCellVsReference()` to manually check how an individual cell in our test set compares to a reference cell of the same or different type. 
+It creates a scatter plot of the chosen cell's expression profile against the specified reference where each point is an individual gene, along with the linear regression fit and Spearman's rank correlation coefficient.
+
+```{r}
+# Get first cell label from our predictions - "acinar" in this case.
+pred$labels[1]
+# Get all cells in reference set with "acinar" label and plot against the first in this list.
+same.type <- grep(pred$labels[1], sceM$label)
+plotCellVsReference(sceG, test.id = 1, ref = sceM, ref.id = same.type[1])
+
+# And now compare to a cell of a different type than our cell of interest.
+diff.type <- seq_along(pred$labels)[-same.type]
+plotCellVsReference(sceG, test.id = 1, ref = sceM, ref.id = diff.type[1])
+```
+
+`plotScoreHeatmap()` can be used to visualize the scores for all cells across all reference labels.
+
+```{r}
+plotScoreHeatmap(pred)
+```
+
+We can also display clusters (or other metadata information) for each cell by setting the `clusters` argument. In this case, we also display which donor the cells came from.
+
+```{r}
+plotScoreHeatmap(pred, clusters=sceG$donor)
+```
+
+As `plotScoreHeatmap()` uses `pheatmap` for plotting, additional arguments can be passed to adjust the heatmap as needed.
+
 # Available reference datasets
 
 `r Biocpkg("SingleR")` also directly provides a number of reference datasets generated from bulk RNA-seq of pure cell types.
-This makes use of Immgen, Blueprint+Encode, the Human Primary Cell Atlas and other resources. 
+This makes use of Immgen, Blueprint+Encode, the Human Primary Cell Atlas and other resources. Run `?getReferenceDataset` for more information about the available reference datasets.
 Each reference dataset is obtained using the `getReferenceDataSet()` function:
 
 ```{r}


### PR DESCRIPTION
 - Added basic visualization examples to the vignette.
 - Went ahead and swapped all instances of `normalize` to `logNormCounts` in the vignette, despite issues with running it on the `sceG` data.