### PR TITLE
Updated plotCellVsReference inputs and fixed its testthat code

### DIFF
--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -11,9 +11,9 @@
 #' or otherwise variance-stabilized), where rows are genes and columns are cells.
 #' Alternatively, a \linkS4class{SummarizedExperiment} object containing such a matrix.
 #' @param ref.id Integer scalar specifying the reference cell/sample to use.
-#' @param test.assay.type Integer scalar or string specifying the assay of \code{test} containing the relevant expression data.  
+#' @param assay.type.test Integer scalar or string specifying the assay of \code{test} containing the relevant expression data.  
 #' Used if \code{test} is a \linkS4class{SummarizedExperiment}.
-#' @param ref.assay.type Integer scalar or string specifying the assay of \code{ref} containing the relevant expression data.  
+#' @param assay.type.ref Integer scalar or string specifying the assay of \code{ref} containing the relevant expression data.  
 #' Used if provided \code{ref} is a \linkS4class{SummarizedExperiment}.
 #'
 #' @return A \link{ggplot} object containing a scatter plot of the cell against a reference.
@@ -44,12 +44,12 @@
 #' @importFrom SummarizedExperiment assay
 #' @importClassesFrom SummarizedExperiment SummarizedExperiment
 #' @importFrom methods is
-plotCellVsReference <- function(test, test.id, ref, ref.id, test.assay.type = 'logcounts', ref.assay.type = 'logcounts') {
+plotCellVsReference <- function(test, test.id, ref, ref.id, assay.type.test = 'logcounts', assay.type.ref = 'logcounts') {
     if (is(test, "SummarizedExperiment")) {
-        test <- assay(test, test.assay.type)
+        test <- assay(test, assay.type.test)
     }
     if (is(ref, "SummarizedExperiment")) {
-        ref <- assay(ref, ref.assay.type)
+        ref <- assay(ref, assay.type.ref)
     }
 
     rownames(test) <- tolower(rownames(test))

--- a/tests/testthat/test-visualizations.R
+++ b/tests/testthat/test-visualizations.R
@@ -3,17 +3,33 @@
 
 colnames(test) <- sprintf("cell_%i", seq_len(ncol(test)))
 pred <- SingleR(test=test, ref=training, labels=training$label, genes="de")
+test.exp <- assay(test,1)
+training.exp <- assay(training,1)
 
 test_that("we can produce expression comparison scatterplots with plotCellVsReference", {
-    expect_error(plotCellVsReference(test,1,training,1), NA) 
-    expect_s3_class(P <- plotCellVsReference(test, 1, training, 1, 1, 1), "ggplot")
-    expect_s3_class(plotCellVsReference(test.exp, 1, training.exp, 1), "ggplot")
-    expect_s3_class(plotCellVsReference(test, 1, training.exp, 1,1,NULL), "ggplot")
-    expect_s3_class(plotCellVsReference(test.exp, 1, training, 1,NULL,1), "ggplot")
-
-    expect_false(isTRUE(all.equal(P, P2 <- plotCellVsReference(test, 2, training, 1, 1, 1))))
-    expect_false(isTRUE(all.equal(P, P3 <- plotCellVsReference(test, 1, training, 2, 1, 1))))
-    expect_false(isTRUE(all.equal(P2, P3)))
+  expect_error(plotCellVsReference(test = test,1,
+                                   ref = training,1,
+                                   5, 5), NULL)
+  expect_s3_class(plotCellVsReference(test = test, 1,
+                                      ref = training, 1,
+                                      1, 1), "ggplot")
+  expect_s3_class(P <- plotCellVsReference(test = test, 1,
+                                           ref = training, 1), "ggplot")
+  expect_s3_class(plotCellVsReference(test = test.exp, 1,
+                                      ref = training.exp, 1), "ggplot")
+  expect_s3_class(plotCellVsReference(test = test, 1,
+                                      ref = training.exp, 1,
+                                      1,5), "ggplot")
+  expect_s3_class(plotCellVsReference(test = test.exp, 1,
+                                      ref = training, 1,
+                                      5,1), "ggplot")
+  expect_false(isTRUE(all.equal(P,
+                                P2 <- plotCellVsReference(test = test, 2,
+                                                          ref = training, 1))))
+  expect_false(isTRUE(all.equal(P, 
+                                P3 <- plotCellVsReference(test = test, 1,
+                                                          ref = training, 2))))
+  expect_false(isTRUE(all.equal(P2, P3)))
 })
 
 test_that("We can produce heatmaps of scores with plotScoreHeatmap", {

--- a/tests/testthat/test-visualizations.R
+++ b/tests/testthat/test-visualizations.R
@@ -7,29 +7,37 @@ test.exp <- assay(test,1)
 training.exp <- assay(training,1)
 
 test_that("we can produce expression comparison scatterplots with plotCellVsReference", {
-  expect_error(plotCellVsReference(test = test,1,
-                                   ref = training,1,
-                                   5, 5), NULL)
-  expect_s3_class(plotCellVsReference(test = test, 1,
-                                      ref = training, 1,
-                                      1, 1), "ggplot")
-  expect_s3_class(P <- plotCellVsReference(test = test, 1,
-                                           ref = training, 1), "ggplot")
-  expect_s3_class(plotCellVsReference(test = test.exp, 1,
-                                      ref = training.exp, 1), "ggplot")
-  expect_s3_class(plotCellVsReference(test = test, 1,
-                                      ref = training.exp, 1,
-                                      1,5), "ggplot")
-  expect_s3_class(plotCellVsReference(test = test.exp, 1,
-                                      ref = training, 1,
-                                      5,1), "ggplot")
-  expect_false(isTRUE(all.equal(P,
-                                P2 <- plotCellVsReference(test = test, 2,
-                                                          ref = training, 1))))
-  expect_false(isTRUE(all.equal(P, 
-                                P3 <- plotCellVsReference(test = test, 1,
-                                                          ref = training, 2))))
-  expect_false(isTRUE(all.equal(P2, P3)))
+    expect_error(plotCellVsReference(
+        test = test,1,
+        ref = training,1,
+        5, 5), NULL)
+    expect_s3_class(plotCellVsReference(
+        test = test, 1,
+        ref = training, 1,
+        1, 1), "ggplot")
+    expect_s3_class(P <- plotCellVsReference(
+        test = test, 1,
+        ref = training, 1), "ggplot")
+    expect_s3_class(plotCellVsReference(
+        test = test.exp, 1,
+        ref = training.exp, 1), "ggplot")
+    expect_s3_class(plotCellVsReference(
+        test = test, 1,
+        ref = training.exp, 1,
+        1,5), "ggplot")
+    expect_s3_class(plotCellVsReference(
+        test = test.exp, 1,
+        ref = training, 1,
+        5,1), "ggplot")
+    expect_false(isTRUE(all.equal(
+        P,
+        P2 <- plotCellVsReference(test = test, 2,
+        ref = training, 1))))
+    expect_false(isTRUE(all.equal(
+        P, 
+        P3 <- plotCellVsReference(test = test, 1,
+        ref = training, 2))))
+    expect_false(isTRUE(all.equal(P2, P3)))
 })
 
 test_that("We can produce heatmaps of scores with plotScoreHeatmap", {

--- a/tests/testthat/test-visualizations.R
+++ b/tests/testthat/test-visualizations.R
@@ -8,35 +8,37 @@ training.exp <- assay(training,1)
 
 test_that("we can produce expression comparison scatterplots with plotCellVsReference", {
     expect_error(plotCellVsReference(
-        test = test,1,
-        ref = training,1,
-        5, 5), NULL)
+        test = test, test.id = 1,
+        ref = training, ref.id = 1,
+        assay.type.test = 5, assay.type.ref = 5), NULL)
     expect_s3_class(plotCellVsReference(
-        test = test, 1,
-        ref = training, 1,
-        1, 1), "ggplot")
+        test = test, test.id = 1,
+        ref = training, ref.id = 1,
+        assay.type.test = 1, assay.type.ref = 1), "ggplot")
     expect_s3_class(P <- plotCellVsReference(
-        test = test, 1,
-        ref = training, 1), "ggplot")
+        test = test, test.id = 1,
+        ref = training, ref.id = 1), "ggplot")
     expect_s3_class(plotCellVsReference(
-        test = test.exp, 1,
-        ref = training.exp, 1), "ggplot")
+        test = test.exp, test.id = 1,
+        ref = training.exp, ref.id = 1), "ggplot")
     expect_s3_class(plotCellVsReference(
-        test = test, 1,
-        ref = training.exp, 1,
-        1,5), "ggplot")
+        test = test, test.id = 1,
+        ref = training.exp, ref.id = 1,
+        assay.type.test = 1, assay.type.ref = 5), "ggplot")
     expect_s3_class(plotCellVsReference(
-        test = test.exp, 1,
-        ref = training, 1,
-        5,1), "ggplot")
+        test = test.exp, test.id = 1,
+        ref = training, ref.id = 1,
+        assay.type.test = 5, assay.type.ref = 1), "ggplot")
     expect_false(isTRUE(all.equal(
         P,
-        P2 <- plotCellVsReference(test = test, 2,
-        ref = training, 1))))
+        P2 <- plotCellVsReference(
+            test = test, test.id = 2,
+            ref = training, ref.id = 1))))
     expect_false(isTRUE(all.equal(
         P, 
-        P3 <- plotCellVsReference(test = test, 1,
-        ref = training, 2))))
+        P3 <- plotCellVsReference(
+            test = test, test.id = 1,
+            ref = training, ref.id = 2))))
     expect_false(isTRUE(all.equal(P2, P3)))
 })
 


### PR DESCRIPTION
visualizations.R, plotCellVsReference:
updated the assay.type inputs in plotCellVsReference to match the rest of the naming scheme:
 - assay.type.sc -> test.assay.type
 - assay.type.train -> ref.assay.type

test-visualizations.R:
Added back expression matrix grabbing in code's setup to facilitate the testing that plotCellVsReference can handle these as input.
Corrected proper assay.data inputs to look for non-existent data slots now that logcounts slot was added in the the setup.R file.