### PR TITLE
Added showing of prune.calls to plotScoreHeatmap (+ manually provided annotations)

### DIFF
--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -145,6 +145,9 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     if (!is.null(labels.use)) {
         scores <- scores[,labels.use]
     }
+    if (show.pruned) {                         # REMOVE after prune.scores added to results.
+        names(prune.calls) <- rownames(scores) # REMOVE after prune.scores added to results.
+    }                                          # REMOVE after prune.scores added to results.
 
     # NOTE: calculation of 'm' before normalization is deliberate.
     m <- rowMaxs(scale(t(scores)))
@@ -183,8 +186,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     if (is.null(args$annotation_col) & (!is.null(clusters) | show.pruned)) {args$annotation_col <- data.frame(row.names = colnames(scores))}
     if(!is.null(clusters)) {args$annotation_col$Clusters <- clusters[order]}
     if(show.pruned) {
-      names(prune.calls) <- colnames(scores) # REMOVE after prune.scores added to results.
-      args$annotation_col$pruned <- prune.calls[colnames(scores)[order]]} # CHANGE to results[colnames(scores)[order],]$pruned after added.
+        args$annotation_col$pruned <- prune.calls[colnames(scores)[order]]} # CHANGE to results[colnames(scores)[order],]$pruned after added.
 
     do.call(pheatmap::pheatmap, args)
 }

--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -165,11 +165,10 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     # Determining how to order the cells. 
     if (!is.null(clusters)) {
         names(clusters) <- rownames(results)
-        # clusters <- data.frame(Clusters = clusters[colnames(scores)], row.names = colnames(scores))
     }
     cluster_cols <- FALSE
     if (order.by.clusters & !is.null(clusters)) {
-        order <- order(clusters)#$Clusters)
+        order <- order(clusters)
     } else if (!is.null(cells.order)){
         order <- cells.order
     } else {

--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -126,7 +126,7 @@ plotCellVsReference <- function(test, test.id, ref, ref.id, assay.type.test = 'l
 #' @importFrom utils head
 #' @importFrom DelayedArray rowMaxs rowMins
 plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
-    clusters = NULL, show.pruned = TRUE, prune.calls,
+    clusters = NULL, show.pruned = FALSE, prune.calls,
     max.labels = 40, normalize = TRUE, cube.normalized = TRUE,
     cells.order=NULL, order.by.clusters=FALSE, 
     ...)

--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -79,7 +79,6 @@ plotCellVsReference <- function(test, test.id, ref, ref.id, assay.type.test = 'l
 #' @param prune.calls Logical vector, the output of \code{\link{pruneScores}}.  This input will be unnecessary once \code{\link{pruneScores}}'s output is added to the SingleR.results dataframe
 #' @param max.labels Integer scalar specifying the maximum number of labels to show.
 #' @param normalize Logical specifying whether correlations should be normalized to lie in [0, 1].
-#' @param cube.normalized Logical, TRUE by default, specifying whether scores of each cell are cubed after being normalized between [0, 1].
 #' @param order.by.clusters Logical scalar specifying if cells should be ordered by \code{clusters} and not by scores.
 #' If set, this takes precedence over \code{cells.order} input.
 #' @param cells.order Integer vector specifying the ordering of cells/columns of the heatmap. 
@@ -127,7 +126,7 @@ plotCellVsReference <- function(test, test.id, ref, ref.id, assay.type.test = 'l
 #' @importFrom DelayedArray rowMaxs rowMins
 plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     clusters = NULL, show.pruned = FALSE, prune.calls,
-    max.labels = 40, normalize = TRUE, cube.normalized = TRUE,
+    max.labels = 40, normalize = TRUE,
     cells.order=NULL, order.by.clusters=FALSE, 
     ...)
 {
@@ -157,7 +156,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
         mmax <- rowMaxs(scores)
         mmin <- rowMins(scores)
         scores <- (scores-mmin)/(mmax-mmin)
-        if (cube.normalized) { scores <- scores^3 }
+        scores <- scores^3
     }
 
     scores <- scores[,seq_len(ncol(scores)) %in% to.keep,drop=FALSE]

--- a/tests/testthat/test-visualizations.R
+++ b/tests/testthat/test-visualizations.R
@@ -59,6 +59,32 @@ test_that("We can produce heatmaps of scores with plotScoreHeatmap", {
     expect_s3_class(plotScoreHeatmap(results = pred, silent=TRUE), "pheatmap")
 })
 
+test_that("cells.use can be combined with annotations & annotations can be combined with eachother", {
+    expect_s3_class(plotScoreHeatmap(results = pred, cells.use = 1:50, clusters = pred$labels), "pheatmap")
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, cells.use = 1:50, clusters = pred$labels,
+        prune.calls = as.character(rep(c(rep(TRUE,24),FALSE),nrow(pred)/25)), # REMOVE LINE after prune.scores added to results.
+        show.pruned = TRUE), "pheatmap")
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, cells.use = 1:50, clusters = pred$labels,
+        annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred)),
+        prune.calls = as.character(rep(c(rep(TRUE,24),FALSE),nrow(pred)/25)), # REMOVE LINE after prune.scores added to results.
+        show.pruned = TRUE), "pheatmap")
+})
+
+test_that("cells.use AND ordering can be combined with annotations", {
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, cells.use = 1:50, clusters = pred$labels,
+        prune.calls = as.character(rep(c(rep(TRUE,24),FALSE),4)), # REMOVE LINE after prune.scores added to results.
+        show.pruned = TRUE,
+        annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred)),
+        cells.order = 1:50), "pheatmap")
+})
+
 test_that("We can pass excess pheatmap::pheatmap parameters through plotScoreHeatmap.", {
     expect_s3_class(plotScoreHeatmap(results = pred, cutree_col = 3), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, fontsize.row = 5), "pheatmap")


### PR DESCRIPTION
visualizations.R, plotScoreHeatmap:

- Added capability to annotate heatmaps with prune.calls:
  - Added show.prune input (Default = FALSE for now) to control whether pruneScores are annotated in the heatmap.
  - Added temporary prune.calls input for setting those calls (with comments marking what we do when this becomes extractable from the results input!)
- Added capability to combine cluster & prune.calls annotation with extra annotations through provision of annotate_col (the normal pheatmap::pheatmap argument for this)

test-visualizations.R:

- Added tests for combination of multiple annotations - clustering, prune.calls, manually provided - and for combination of these with `cells.use` subsetting and `cells.order` ordering.