### PR TITLE
Fix a data trimming error in pruneScoresHeatmap

### DIFF
--- a/R/visualizations.R
+++ b/R/visualizations.R
@@ -81,8 +81,8 @@ plotCellVsReference <- function(test, test.id, ref, ref.id, assay.type.test = 'l
 #' @param order.by.clusters Logical scalar specifying if cells should be ordered by \code{clusters} and not by scores.
 #' If set, this takes precedence over \code{cells.order} input.
 #' @param cells.order Integer vector specifying the ordering of cells/columns of the heatmap. 
+#' Regardless of \code{cells.use}, this input should be the the same length as the total number of cells.
 #' If set, turns off clustering of columns based on scoring.
-#' Note: When used alongside \code{cells.use}, both arguments should be the same length. 
 #' @param annotation_col A data.frame containing data for additional/alternative column annotations 
 #' (clustering and pruning annotations are automatically added).
 #' Row names should be the names of the cells, and columns should be named with the title to be displayed for each annotation bar.
@@ -163,6 +163,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     if (!is.null(cells.use)) {
         scores <- scores[cells.use,,drop=FALSE]
         clusters <- clusters[cells.use]
+        cells.order <- cells.order[cells.use]
     }
     if (!is.null(labels.use)) {
         scores <- scores[,labels.use,drop=FALSE]
@@ -173,7 +174,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     if (order.by.clusters) {
         order <- order(clusters)
     } else if (!is.null(cells.order)) {
-        order <- cells.order
+        order <- order(cells.order)
     } else {
         # no ordering requested
         order <- seq_len(nrow(scores))

--- a/tests/testthat/test-visualizations.R
+++ b/tests/testthat/test-visualizations.R
@@ -95,7 +95,7 @@ test_that("cells.use can be combined with ordering (by cells or by cluster)", {
         annotation_col = data.frame(
             annot = seq_len(nrow(pred)),
             row.names = row.names(pred)),
-        cells.order = 1:50), "pheatmap")
+        cells.order = 1:100), "pheatmap")
 
     expect_s3_class(plotScoreHeatmap(
         results = pred, cells.use = 1:50, clusters = pred$labels,
@@ -148,7 +148,7 @@ test_that("Annotations stay linked, even with cells.use, cells.order, or order.b
     #Reference plot, but only half: Every tenth cell, pruned = TRUE. Clusters from 50:1. annot from 100:51.
     expect_s3_class(plotScoreHeatmap(
         results = pred,
-        cells.order = seq_len(nrow(pred))[1:50],
+        cells.order = seq_len(nrow(pred)),
         # order.by.clusters = TRUE,
         cells.use = 1:50,
         clusters = seq(nrow(pred),1),
@@ -163,7 +163,7 @@ test_that("Annotations stay linked, even with cells.use, cells.order, or order.b
         results = pred,
         cells.order = seq_len(nrow(pred)),
         # order.by.clusters = TRUE,
-        # cells.use = 1:100,
+        # cells.use = 1:50,
         clusters = seq(nrow(pred),1),
         show.pruned = TRUE,
         annotation_col = data.frame(


### PR DESCRIPTION
In our code reorganization, we missed a need to change one line of code.
Current code incorrectly trims cells based on the number of labels.
Fix: I changed an `ncol` to `nrow` because code reorganization had moved the `ordering` chunk above the `normalization` chunk in which the scores matrix gets transposed.