### PR TITLE
changed cell ordering to be by labels by default

### DIFF
--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -124,10 +124,12 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     scores <- results$scores
     rownames(scores) <- rownames(results)
 
-    # Trim the scores by requested cells or labels
+    # Trim the scores and potential ordering vars by requested cells or labels
+    labels <- results$labels
     if (!is.null(cells.use)) {
         scores <- scores[cells.use,,drop=FALSE]
         clusters <- clusters[cells.use]
+        labels <- labels[cells.use]
         cells.order <- cells.order[cells.use]
     }
     if (!is.null(labels.use)) {
@@ -144,7 +146,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
             order <- order(cells.order)
         } else {
             order.stat <- switch(match.arg(order.by),
-                labels=results$labels,
+                labels=labels,
                 clusters=clusters
             )
             if (is.null(order.stat)) {

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -150,7 +150,10 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
                 clusters=clusters
             )
             if (is.null(order.stat)) {
-                stop("Nothing to order by. Did you provide clustering to `clusters`?")
+                stop(sprintf(
+                    paste0("%s input is required when ",
+                        sQuote("order.by = %s")),
+                    sQuote("clusters"), dQuote("clusters")))
             }
             order <- order(order.stat)
         }

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -150,7 +150,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
                 clusters=clusters
             )
             if (is.null(order.stat)) {
-                stop("Nothing to order by. Did you provide clusters?")
+                stop("Nothing to order by. Did you provide clustering to `clusters`?")
             }
             order <- order(order.stat)
         }

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -94,7 +94,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     cells.order = NULL, order.by = c("labels","clusters"), cluster_cols = FALSE,
     annotation_col = NULL, show_colnames = FALSE, color = NULL, ...)
 {
-    order.by <- match.arg(order.by)
+
     if (is.null(rownames(results))) {
         rownames(results) <- seq_len(nrow(results))
     }
@@ -142,10 +142,15 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     } else {
         if (!is.null(cells.order)) {
             order <- order(cells.order)
-        } else if (order.by == "labels") {
-            order <- order(results$labels)
         } else {
-            order <- order(clusters)
+            order.stat <- switch(match.arg(order.by),
+                labels=results$labels,
+                clusters=clusters
+            )
+            if (is.null(order.stat)) {
+                stop("Nothing to order by. Did you provide clusters?")
+            }
+            order <- order(order.stat)
         }
     }
 

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -12,12 +12,13 @@
 #' @param show.pruned Logical indicating whether the pruning status of the labels should be shown as an annotation bar, as defined by \code{\link{pruneScores}}.
 #' @param max.labels Integer scalar specifying the maximum number of labels to show.
 #' @param normalize Logical specifying whether correlations should be normalized to lie in [0, 1].
-#' @param order.by.clusters Logical scalar specifying if cells should be ordered by \code{clusters} and not by scores.
-#' If set, this takes precedence over \code{cells.order} input.
+#' @param order.by String providing the annotation to be used for clustering.
+#' Can be "labels" (default) or "clusters" (when provided).
+#' Subordinate to \code{cells.order} and \code{cluster_cols}.
 #' @param cells.order Integer vector specifying the ordering of cells/columns of the heatmap.
 #' Regardless of \code{cells.use}, this input should be the the same length as the total number of cells.
-#' If set, turns off clustering of columns based on scoring.
-#' @param annotation_col,show_colnames,color,... Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.
+#' Subordinate to \code{cluster_cols}.
+#' @param annotation_col,cluster_cols,show_colnames,color,... Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.
 #'
 #' @return A heatmap of assignment scores is generated on the current graphics device using \pkg{pheatmap}.
 #'
@@ -90,9 +91,10 @@
 plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     clusters = NULL, show.labels = TRUE, show.pruned = FALSE,
     max.labels = 40, normalize = TRUE,
-    cells.order=NULL, order.by.clusters=FALSE,
+    cells.order = NULL, order.by = c("labels","clusters"), cluster_cols = FALSE,
     annotation_col = NULL, show_colnames = FALSE, color = NULL, ...)
 {
+    order.by <- match.arg(order.by)
     if (is.null(rownames(results))) {
         rownames(results) <- seq_len(nrow(results))
     }
@@ -133,15 +135,18 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     }
 
     # Determining how to order the cells.
-    cluster_cols <- FALSE
-    if (order.by.clusters) {
-        order <- order(clusters)
-    } else if (!is.null(cells.order)) {
-        order <- order(cells.order)
-    } else {
-        # no ordering requested
+    #   Simply use current order if clustering turned on.
+    #   Otherwise, by cells.order, if provided, else by order.by(=Labels, default).
+    if (cluster_cols) {
         order <- seq_len(nrow(scores))
-        cluster_cols <- TRUE
+    } else {
+        if (!is.null(cells.order)) {
+            order <- order(cells.order)
+        } else if (order.by == "labels") {
+            order <- order(results$labels)
+        } else {
+            order <- order(clusters)
+        }
     }
 
     # Determine labels to show based on 'max.labels' with the highest

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -150,10 +150,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
                 clusters=clusters
             )
             if (is.null(order.stat)) {
-                stop(sprintf(
-                    paste0("%s input is required when ",
-                        sQuote("order.by = %s")),
-                    sQuote("clusters"), dQuote("clusters")))
+                stop("'clusters' input is required when 'order.by=\"clusters\"'")
             }
             order <- order(order.stat)
         }

--- a/man/plotScoreHeatmap.Rd
+++ b/man/plotScoreHeatmap.Rd
@@ -14,7 +14,7 @@ plotScoreHeatmap(
   max.labels = 40,
   normalize = TRUE,
   cells.order = NULL,
-  order.by = "labels",
+  order.by = c("labels", "clusters"),
   cluster_cols = FALSE,
   annotation_col = NULL,
   show_colnames = FALSE,
@@ -46,7 +46,7 @@ Regardless of \code{cells.use}, this input should be the the same length as the 
 Subordinate to \code{cluster_cols}.}
 
 \item{order.by}{String providing the annotation to be used for clustering.
-Can be "Labels", "Clusters" (if provided), or the name of any other annotation provided to \code{annotation_col}.
+Can be "labels" (default) or "clusters" (when provided).
 Subordinate to \code{cells.order} and \code{cluster_cols}.}
 
 \item{annotation_col, cluster_cols, show_colnames, color, ...}{Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.}

--- a/man/plotScoreHeatmap.Rd
+++ b/man/plotScoreHeatmap.Rd
@@ -14,9 +14,11 @@ plotScoreHeatmap(
   max.labels = 40,
   normalize = TRUE,
   cells.order = NULL,
-  order.by.clusters = FALSE,
+  order.by = "labels",
+  cluster_cols = FALSE,
   annotation_col = NULL,
   show_colnames = FALSE,
+  color = NULL,
   ...
 )
 }
@@ -41,12 +43,13 @@ If \code{NULL}, all labels available in \code{results} are presented.}
 
 \item{cells.order}{Integer vector specifying the ordering of cells/columns of the heatmap.
 Regardless of \code{cells.use}, this input should be the the same length as the total number of cells.
-If set, turns off clustering of columns based on scoring.}
+Subordinate to \code{cluster_cols}.}
 
-\item{order.by.clusters}{Logical scalar specifying if cells should be ordered by \code{clusters} and not by scores.
-If set, this takes precedence over \code{cells.order} input.}
+\item{order.by}{String providing the annotation to be used for clustering.
+Can be "Labels", "Clusters" (if provided), or the name of any other annotation provided to \code{annotation_col}.
+Subordinate to \code{cells.order} and \code{cluster_cols}.}
 
-\item{annotation_col, show_colnames, ...}{Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.}
+\item{annotation_col, cluster_cols, show_colnames, color, ...}{Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.}
 }
 \value{
 A heatmap of assignment scores is generated on the current graphics device using \pkg{pheatmap}.

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -49,7 +49,7 @@ test_that("Error is thrown when order.by = `clusters` but no clusters are given.
     expect_error(plotScoreHeatmap(
         results = pred, cells.use = 1:50,
         order.by = "clusters"),
-        "‘clusters’ input is required when ‘order.by = “clusters”’")
+        "'clusters' input is required when 'order.by=\"clusters\"'")
 })
 
 

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -9,20 +9,20 @@ training.exp <- assay(training,1)
 test_that("We can produce heatmaps of scores with plotScoreHeatmap", {
     expect_s3_class(plotScoreHeatmap(results = pred), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, normalize = FALSE), "pheatmap")
-  
+
     expect_s3_class(plotScoreHeatmap(results = pred, cells.use = 1:50), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, cells.use = rownames(pred)[1:50]), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, cells.order=seq_len(nrow(pred))), "pheatmap")
-  
+
     expect_s3_class(plotScoreHeatmap(results = pred, labels.use = levels(as.factor(pred$labels))[1:3]), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, max.labels = length(levels(as.factor(pred$labels)))-1), "pheatmap")
-  
+
     expect_s3_class(plotScoreHeatmap(results = pred, clusters = pred$labels), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, clusters = pred$labels, order.by.clusters=TRUE), "pheatmap")
-    
+
     expect_s3_class(plotScoreHeatmap(results = pred, show.pruned = TRUE), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred, show.labels = TRUE), "pheatmap")
-  
+
     expect_s3_class(plotScoreHeatmap(results = pred, silent=TRUE), "pheatmap")
     expect_s3_class(plotScoreHeatmap(results = pred,
         annotation_col = data.frame(
@@ -45,23 +45,12 @@ test_that("cells.use can be combined with annotations & annotations can be combi
         show.pruned = TRUE), "pheatmap")
 })
 
-test_that("cells.use can be combined with ordering (by cells or by cluster)", {
-    expect_s3_class(plotScoreHeatmap(
-        results = pred, cells.use = 1:50, clusters = pred$labels,
-        show.pruned = TRUE,
-        annotation_col = data.frame(
-            annot = seq_len(nrow(pred)),
-            row.names = row.names(pred)),
-        cells.order = 1:100), "pheatmap")
-
-    expect_s3_class(plotScoreHeatmap(
-        results = pred, cells.use = 1:50, clusters = pred$labels,
-        show.pruned = TRUE,
-        annotation_col = data.frame(
-            annot = seq_len(nrow(pred)),
-            row.names = row.names(pred)),
-        order.by.clusters = TRUE), "pheatmap")
+test_that("Error is thrown when order.by = `clusters` but no clusters are given.", {
+    expect_error(plotScoreHeatmap(
+        results = pred, cells.use = 1:50,
+        order.by = "clusters"))
 })
+
 
 test_that("We can pass excess pheatmap::pheatmap parameters through plotScoreHeatmap.", {
     expect_s3_class(plotScoreHeatmap(results = pred, cutree_col = 3), "pheatmap")
@@ -75,7 +64,7 @@ test_that("We can pass excess pheatmap::pheatmap parameters through plotScoreHea
 test_that("Annotations stay linked, even with cells.use, cells.order, or order.by.clusters = TRUE", {
     # Make prune.call TRUE for every 10th value.  (We need known order for testing annotation placement.)
     pred$pruned.labels <- rep(c(rep(FALSE,9),NA),nrow(pred)/10)
-    
+
     #Reference plot: Every tenth cell, pruned = TRUE. Clusters from 100:1. annot from 1:100.
     expect_s3_class(plotScoreHeatmap(
         results = pred,
@@ -132,7 +121,7 @@ test_that("Annotations stay linked, even with cells.use, cells.order, or order.b
 test_that("Row and Column annotation coloring works", {
     # Make prune.call TRUE for every 10th value.
     pred$pruned.labels <- rep(c(rep(FALSE,9),NA),nrow(pred)/10)
-    
+
     #When works:
         # Clusters and Continuous are shades of the same color
         # Pruned and Discrete are many discrete colors
@@ -146,4 +135,41 @@ test_that("Row and Column annotation coloring works", {
             Continuous = as.numeric(seq_len(ncol(pred$scores))),
             row.names = colnames(pred$scores))),
         "pheatmap")
+})
+
+test_that("Ordering works (by cells, by labels, by clusters) and can be combined with cells.use", {
+    # Base Default: ordering by *labels*
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, clusters = g, annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred))), "pheatmap")
+    # Ordering should follow *annot* because of cells.order
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, clusters = g, annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred)),
+        cells.use = 1:50,
+        cells.order = 1:100), "pheatmap")
+    # Ordering should still follow *annot* because cells.order > order.by
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, clusters = g, annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred)),
+        cells.use = 1:50,
+        cells.order = 1:100,
+        order.by = "labels"), "pheatmap")
+    # Ordering should follow *labels*
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, clusters = g, annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred)),
+        cells.use = 1:50,
+        order.by = "labels"), "pheatmap")
+    # Ordering should follow *clusters*
+    expect_s3_class(plotScoreHeatmap(
+        results = pred, clusters = g, annotation_col = data.frame(
+            annot = seq_len(nrow(pred)),
+            row.names = row.names(pred)),
+        cells.use = 1:50,
+        order.by = "clusters"), "pheatmap")
 })

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -48,7 +48,8 @@ test_that("cells.use can be combined with annotations & annotations can be combi
 test_that("Error is thrown when order.by = `clusters` but no clusters are given.", {
     expect_error(plotScoreHeatmap(
         results = pred, cells.use = 1:50,
-        order.by = "clusters"))
+        order.by = "clusters"),
+        "‘clusters’ input is required when ‘order.by = “clusters”’")
 })
 
 
@@ -143,21 +144,24 @@ test_that("Ordering works (by cells, by labels, by clusters) and can be combined
         results = pred, clusters = g, annotation_col = data.frame(
             annot = seq_len(nrow(pred)),
             row.names = row.names(pred))), "pheatmap")
+
     # Ordering should follow *annot* because of cells.order
     expect_s3_class(plotScoreHeatmap(
         results = pred, clusters = g, annotation_col = data.frame(
             annot = seq_len(nrow(pred)),
             row.names = row.names(pred)),
         cells.use = 1:50,
-        cells.order = 1:100), "pheatmap")
+        cells.order = seq_len(nrow(pred))), "pheatmap")
+
     # Ordering should still follow *annot* because cells.order > order.by
     expect_s3_class(plotScoreHeatmap(
         results = pred, clusters = g, annotation_col = data.frame(
             annot = seq_len(nrow(pred)),
             row.names = row.names(pred)),
         cells.use = 1:50,
-        cells.order = 1:100,
+        cells.order = seq_len(nrow(pred)),
         order.by = "labels"), "pheatmap")
+
     # Ordering should follow *labels*
     expect_s3_class(plotScoreHeatmap(
         results = pred, clusters = g, annotation_col = data.frame(
@@ -165,6 +169,7 @@ test_that("Ordering works (by cells, by labels, by clusters) and can be combined
             row.names = row.names(pred)),
         cells.use = 1:50,
         order.by = "labels"), "pheatmap")
+
     # Ordering should follow *clusters*
     expect_s3_class(plotScoreHeatmap(
         results = pred, clusters = g, annotation_col = data.frame(


### PR DESCRIPTION
Changed the `order.by.clusters = FALSE` input to `order.by = c("labels", "clusters")`

Added `cluster_cols = FALSE` arguement.

Default ordering: by labels
Input priority when things are given:
1. cluster if `cluster_cols` set to TRUE
2. order by `cells.order` if provided
3. order by `order.by` request