### PR TITLE
Improved trimming of labels in combined `plotscoreHeatmap`s

### DIFF
--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -401,10 +401,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     scores, labels.use, max.labels, normalize, scores.title) {
 
     # Trim by labels (remove any with no scores)
-    all.na <- vapply(
-        seq_len(ncol(scores)),
-        function(x) all(is.na(scores[,x])),
-        FUN.VALUE = logical(1))
+    all.na <- apply(scores, 2, FUN = function(x) all(is.na(x)))
     scores <- scores[,!all.na]
 	
 	# Trim by labels (labels.use)

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -48,9 +48,13 @@
 #' Note that scores shown in the heatmap are initial scores prior to the fine-tuning step, so the reported labels may not match up to the visual maximum for each cell in the heatmap.
 #'
 #' If \code{max.labels} is less than the total number of unique labels, only the top labels are shown in the plot.
-#' Specifically, the set of scores for each cell is centred and scaled, and the maximum transformed score for each label is used to choose the labels to retain.
-#' Alternatively, for recomputed scores of combined predictions, the number cells for which each label was the best call (primary) or for which each label was an individual reference's suggestion (secondary) are used to choose the labels to retain.
-#'
+#' Labels that were called most frequently are prioritized.
+#' Then remaining labels are selected based on:
+#' \itemize{
+#' \item General case: Labels with max z-scores after per-cell centering and scaling of the scores matrix.
+#' \item Recomputed scores of combined predictions: Labels which were suggested most frequently by individual references.
+#' }
+#' 
 #' @section Working with combined results:
 #' When \code{results} are the output of a combined prediction (see \code{?\link{combine-predictions}}),
 #' \code{scores.use} and \code{calls.use} are used to indicate which prediction's scores or labels should be presented.
@@ -582,6 +586,6 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     }
     names(df_colors) <- names(annotation_df)
     list(df_colors = df_colors,
-         next.color.index.discrete = next.color.index.discrete,
-         next.color.index.numeric = next.color.index.numeric)
+        next.color.index.discrete = next.color.index.discrete,
+        next.color.index.numeric = next.color.index.numeric)
 }

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -47,8 +47,9 @@
 #' If \code{show.labels=TRUE}, an annotation bar will be added to the heatmap indicating labels assigned to the cells.
 #' Note that scores shown in the heatmap are initial scores prior to the fine-tuning step, so the reported labels may not match up to the visual maximum for each cell in the heatmap.
 #'
-#' If \code{max.labels} is less than the total number of unique labels, only the labels with the largest maximum scores are shown in the plot.
+#' If \code{max.labels} is less than the total number of unique labels, only the top labels are shown in the plot.
 #' Specifically, the set of scores for each cell is centred and scaled, and the maximum transformed score for each label is used to choose the labels to retain.
+#' Alternatively, for recomputed scores of combined predictions, the number cells for which each label was the best call (primary) or for which each label was an individual reference's suggestion (secondary) are used to choose the labels to retain.
 #'
 #' @section Working with combined results:
 #' When \code{results} are the output of a combined prediction (see \code{?\link{combine-predictions}}),

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -403,8 +403,8 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     # Trim by labels (remove any with no scores)
     all.na <- apply(scores, 2, FUN = function(x) all(is.na(x)))
     scores <- scores[,!all.na]
-	
-	# Trim by labels (labels.use)
+
+    # Trim by labels (labels.use)
     if (!is.null(labels.use)) {
         labels.use <- labels.use[labels.use %in% colnames(scores)]
         if (length(labels.use)>0){
@@ -416,18 +416,18 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
 
     ## Trim by labels (max.labels) & normalize
     # Determine labels to show based on 'max.labels' with the highest...
-    if (sum(is.na(scores)) < 0.10*prod(dim(scores))) {
-    	# (Individual reference, should really have no NAs)
-	    # pre-normalized scores relative to mean and stdev (per label)
-    	maxs <- rowMaxs(scale(t(scores)), na.rm = TRUE)
-    	to.keep <- order(maxs, decreasing = TRUE)[seq_len(max.labels)]
+    if (any(is.na(scores))) {
+        # (individual reference)
+        # pre-normalized scores relative to mean and stdev (per label)
+        maxs <- rowMaxs(scale(t(scores)), na.rm = TRUE)
+        to.keep <- order(maxs, decreasing = TRUE)[seq_len(max.labels)]
     } else {
-    	# (Combined reference, should confoundingly many NAs)
-    	# number of calls, with highest number of times scored in general as tie-breaker
-    	calcs <- apply(scores, 2, FUN = function(x) sum(!is.na(x)))
-    	# factor ensures labels with no calls are kept
-    	calls <- table(factor(apply(scores, 1, which.max), levels = seq_len(ncol(scores))))
-    	to.keep <- order(calls, calcs, decreasing = TRUE)[seq_len(max.labels)]
+        # (combined scores)
+        # number of final calls, then the number of times scored in general
+        num.calcs <- apply(scores, 2, FUN = function(x) sum(!is.na(x)))
+        # factor ensures labels with no calls are kept
+        times.best <- tabulate(apply(scores, 1, which.max), nbins = ncol(scores))
+        to.keep <- order(times.best, num.calcs, decreasing = TRUE)[seq_len(max.labels)]
     }
 
     # Normalize the scores between [0, 1] and cube to create more separation.

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -400,7 +400,14 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
 .trim_byLabel_and_normalize_scores <- function(
     scores, labels.use, max.labels, normalize, scores.title) {
 
-    # Trim by labels (labels.use)
+    # Trim by labels (remove any with no scores)
+    all.na <- vapply(
+        seq_len(ncol(scores)),
+        function(x) all(is.na(scores[,x])),
+        FUN.VALUE = logical(1))
+    scores <- scores[,!all.na]
+	
+	# Trim by labels (labels.use)
     if (!is.null(labels.use)) {
         labels.use <- labels.use[labels.use %in% colnames(scores)]
         if (length(labels.use)>0){

--- a/man/plotScoreHeatmap.Rd
+++ b/man/plotScoreHeatmap.Rd
@@ -91,8 +91,12 @@ If \code{show.labels=TRUE}, an annotation bar will be added to the heatmap indic
 Note that scores shown in the heatmap are initial scores prior to the fine-tuning step, so the reported labels may not match up to the visual maximum for each cell in the heatmap.
 
 If \code{max.labels} is less than the total number of unique labels, only the top labels are shown in the plot.
-Specifically, the set of scores for each cell is centred and scaled, and the maximum transformed score for each label is used to choose the labels to retain.
-Alternatively, for recomputed scores of combined predictions, the number cells for which each label was the best call (primary) or for which each label was an individual reference's suggestion (secondary) are used to choose the labels to retain.
+Labels that were called most frequently are prioritized.
+Then remaining labels are selected based on:
+\itemize{
+\item General case: Labels with max z-scores after per-cell centering and scaling of the scores matrix.
+\item Recomputed scores of combined predictions: Labels which were suggested most frequently by individual references.
+}
 }
 \section{Working with combined results}{
 

--- a/man/plotScoreHeatmap.Rd
+++ b/man/plotScoreHeatmap.Rd
@@ -90,8 +90,9 @@ Users can then easily identify the high-scoring labels associated with each cell
 If \code{show.labels=TRUE}, an annotation bar will be added to the heatmap indicating labels assigned to the cells.
 Note that scores shown in the heatmap are initial scores prior to the fine-tuning step, so the reported labels may not match up to the visual maximum for each cell in the heatmap.
 
-If \code{max.labels} is less than the total number of unique labels, only the labels with the largest maximum scores are shown in the plot.
+If \code{max.labels} is less than the total number of unique labels, only the top labels are shown in the plot.
 Specifically, the set of scores for each cell is centred and scaled, and the maximum transformed score for each label is used to choose the labels to retain.
+Alternatively, for recomputed scores of combined predictions, the number cells for which each label was the best call (primary) or for which each label was an individual reference's suggestion (secondary) are used to choose the labels to retain.
 }
 \section{Working with combined results}{
 

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -285,6 +285,29 @@ test_that("heatmap multi-ref - labels with no scores are removed", {
             scores.use = 0)$mat))
 })
 
+test_that("heatmap multi-ref - labels with least scores/calcs are removed by 'max.labels'", {
+    combined$scores <- cbind(combined$scores, "neverBest" = -1)
+    combined$scores <- cbind(combined$scores, "rarelyCalc" = NA)
+    combined$scores[1,"rarelyCalc"] <- -1 
+    expect_true(all(c("neverBest", "rarelyCalc") %in% colnames(combined$scores)))
+    
+    # Both there with no trimming
+    expect_true(all(c("neverBest", "rarelyCalc") %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    	max.labels = 40)$mat)))
+    
+    # The rarely picked for calculation "rarelyCalc" label should be removed first
+    expect_true("neverBest" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    	max.labels = 11)$mat))
+    expect_false("rarelyCalc" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    	max.labels = 11)$mat))
+    
+    # The never picked as final label "neverBest" label should be removed next
+    expect_false("neverBest" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    	max.labels = 10)$mat))
+    expect_false("rarelyCalc" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    	max.labels = 10)$mat))
+})
+
 test_that("heatmap multi-ref - Other typical adjustments throw no unexpected errors", {
     # Our vars
     expect_s3_class(plotScoreHeatmap(results = combined,

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -278,6 +278,18 @@ test_that("heatmap multi-ref - 'na.color'", {
         "#000000")
 })
 
+test_that("heatmap multi-ref - labels with no scores are removed", {
+    combined$scores <- cbind(combined$scores, "f" = NA)
+    combined$scores <- cbind(combined$scores, "F" = NA)
+    expect_equal(
+        c("F","f") %in% colnames(combined$scores),
+        c(TRUE, TRUE))
+    expect_equal(
+        c("F","f") %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE,
+            scores.use = 0)$mat),
+        c(FALSE, FALSE))
+})
+
 test_that("heatmap multi-ref - Other typical adjustments throw no unexpected errors", {
     # Our vars
     expect_s3_class(plotScoreHeatmap(results = combined,

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -280,14 +280,9 @@ test_that("heatmap multi-ref - 'na.color'", {
 
 test_that("heatmap multi-ref - labels with no scores are removed", {
     combined$scores <- cbind(combined$scores, "f" = NA)
-    combined$scores <- cbind(combined$scores, "F" = NA)
-    expect_equal(
-        c("F","f") %in% colnames(combined$scores),
-        c(TRUE, TRUE))
-    expect_equal(
-        c("F","f") %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE,
-            scores.use = 0)$mat),
-        c(FALSE, FALSE))
+    expect_true("f" %in% colnames(combined$scores))
+    expect_false("f" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE,
+            scores.use = 0)$mat))
 })
 
 test_that("heatmap multi-ref - Other typical adjustments throw no unexpected errors", {

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -285,24 +285,24 @@ test_that("heatmap multi-ref - labels with no scores are removed", {
             scores.use = 0)$mat))
 })
 
-test_that("heatmap multi-ref - labels with least scores/calcs are removed by 'max.labels'", {
-    combined$scores <- cbind(combined$scores, "neverBest" = -1)
+test_that("heatmap multi-ref - labels with least calls/calcs are removed by 'max.labels'", {
+    combined$scores <- cbind(combined$scores, "neverCalled" = 1) # actual score is immaterial
     combined$scores <- cbind(combined$scores, "rarelyCalc" = NA)
-    combined$scores[1,"rarelyCalc"] <- -1 # Needs at least one score to not be removed anyway.
-    expect_true(all(c("neverBest", "rarelyCalc") %in% colnames(combined$scores)))
+    combined$scores[1,"rarelyCalc"] <- 1 # Needs at least one score to not be removed anyway.
+    expect_true(all(c("neverCalled", "rarelyCalc") %in% colnames(combined$scores)))
     
     # Both there with no trimming
-    expect_true(all(c("neverBest", "rarelyCalc") %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    expect_true(all(c("neverCalled", "rarelyCalc") %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
         max.labels = 40)$mat)))
     
     # The rarely picked for calculation "rarelyCalc" label should be removed first
-    expect_true("neverBest" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    expect_true("neverCalled" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
         max.labels = 11)$mat))
     expect_false("rarelyCalc" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
         max.labels = 11)$mat))
     
-    # The never picked as final label "neverBest" label should be removed next
-    expect_false("neverBest" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
+    # The never picked as final label "neverCalled" label should be removed next
+    expect_false("neverCalled" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
         max.labels = 10)$mat))
     expect_false("rarelyCalc" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
         max.labels = 10)$mat))

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -288,24 +288,24 @@ test_that("heatmap multi-ref - labels with no scores are removed", {
 test_that("heatmap multi-ref - labels with least scores/calcs are removed by 'max.labels'", {
     combined$scores <- cbind(combined$scores, "neverBest" = -1)
     combined$scores <- cbind(combined$scores, "rarelyCalc" = NA)
-    combined$scores[1,"rarelyCalc"] <- -1 
+    combined$scores[1,"rarelyCalc"] <- -1 # Needs at least one score to not be removed anyway.
     expect_true(all(c("neverBest", "rarelyCalc") %in% colnames(combined$scores)))
     
     # Both there with no trimming
     expect_true(all(c("neverBest", "rarelyCalc") %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
-    	max.labels = 40)$mat)))
+        max.labels = 40)$mat)))
     
     # The rarely picked for calculation "rarelyCalc" label should be removed first
     expect_true("neverBest" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
-    	max.labels = 11)$mat))
+        max.labels = 11)$mat))
     expect_false("rarelyCalc" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
-    	max.labels = 11)$mat))
+        max.labels = 11)$mat))
     
     # The never picked as final label "neverBest" label should be removed next
     expect_false("neverBest" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
-    	max.labels = 10)$mat))
+        max.labels = 10)$mat))
     expect_false("rarelyCalc" %in% rownames(plotScoreHeatmap(results = combined, silent = TRUE, return.data = TRUE, scores.use = 0,
-    	max.labels = 10)$mat))
+        max.labels = 10)$mat))
 })
 
 test_that("heatmap multi-ref - Other typical adjustments throw no unexpected errors", {


### PR DESCRIPTION
As a first step, this PR adds the removal of labels which have zero scores in `plotscoreHeatmap` prior to trimming by `labels.use` to ensure that `labels.use` input still gets ignored if it would reduce the scores matrix to zero labels.