### PR TITLE
Began relaxing row name consistency during combining.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SingleR
 Title: Reference-Based Single-Cell RNA-Seq Annotation
-Version: 1.5.1
-Date: 2020-11-07
+Version: 1.5.2
+Date: 2020-11-28
 Authors@R: c(person("Dvir", "Aran", email="dvir.aran@ucsf.edu", role=c("aut", "cph")),
     person("Aaron", "Lun", email="infinite.monkeys.with.keyboards@gmail.com", role=c("ctb", "cre")),
     person("Daniel", "Bunis", role="ctb"),

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,3 +17,7 @@ recompute_scores <- function(Groups, Exprs, Labels, References, Genes, quantile)
     .Call('_SingleR_recompute_scores', PACKAGE = 'SingleR', Groups, Exprs, Labels, References, Genes, quantile)
 }
 
+recompute_scores_with_na <- function(Groups, Exprs, Labels, References, Genes, quantile) {
+    .Call('_SingleR_recompute_scores_with_na', PACKAGE = 'SingleR', Groups, Exprs, Labels, References, Genes, quantile)
+}
+

--- a/R/combineRecomputedResults.R
+++ b/R/combineRecomputedResults.R
@@ -131,7 +131,7 @@ combineRecomputedResults <- function(results, test, trained, quantile=0.8,
     refnames <- Reduce(intersect, refnames)
     if (has.lost <- !all(universe %in% refnames)) {
         if (warn.lost) {
-            stop("not all markers are present across all 'results'")
+            warning("entries of 'trained' differ in the universe of available markers")
         }
         if (!allow.lost) {
             universe <- intersect(universe, refnames)
@@ -240,6 +240,7 @@ combineRecomputedResults <- function(results, test, trained, quantile=0.8,
         lost <- is.na(m)
         m[lost] <- 1L
         output <- x[m,,drop=FALSE]
+        rownames(output) <- universe
         output <- .realize_reference(output)
         output[lost,] <- NA_real_
         output

--- a/R/fine_tune.R
+++ b/R/fine_tune.R
@@ -27,7 +27,7 @@
         lapply(markers, function(x) match(x, universe) - 1L)
     })
 
-    references <- .realize_references(references)
+    references <- lapply(references, .realize_reference)
 
     # We assume that classifySingleR() has already set up the backend.
     bp.out <- colBlockApply(exprs, FUN=.fine_tune_de0, BPPARAM=BPPARAM,
@@ -53,7 +53,7 @@
 .fine_tune_sd <- function(exprs, scores, references, quantile, tune.thresh, median.mat, sd.thresh, BPPARAM=SerialParam()) {
     stopifnot(identical(names(references), colnames(scores)))
 
-    references <- .realize_references(references)
+    references <- lapply(references, .realize_reference)
 
     bp.out <- colBlockApply(exprs, FUN=.fine_tune_sd0, BPPARAM=BPPARAM, 
         scores=t(scores), References=references, quantile=quantile, 

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,12 +72,10 @@
 #' @importFrom DelayedArray is_sparse
 #' @importFrom methods as
 #' @importClassesFrom Matrix dgCMatrix
-.realize_references <- function(ref) {
-    lapply(ref, function(x) {
-        if (is_sparse(x)) {
-            as(x, "dgCMatrix")
-        } else {
-            as.matrix(x)
-        }
-    })
+.realize_reference <- function(ref) {
+    if (is_sparse(x)) {
+        as(x, "dgCMatrix")
+    } else {
+        as.matrix(x)
+    }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,7 +72,7 @@
 #' @importFrom DelayedArray is_sparse
 #' @importFrom methods as
 #' @importClassesFrom Matrix dgCMatrix
-.realize_reference <- function(ref) {
+.realize_reference <- function(x) {
     if (is_sparse(x)) {
         as(x, "dgCMatrix")
     } else {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,10 @@
 \title{SingleR News}
 \encoding{UTF-8}
 
+\section{Version 1.6.0}{\itemize{
+\item Relaxed the requirements for consistent row names in \code{combineRecomputedResults()}.
+}}
+
 \section{Version 1.4.0}{\itemize{
 \item Migrated all of the dataset getter functions to the \pkg{celldex} package.
 

--- a/man/combineRecomputedResults.Rd
+++ b/man/combineRecomputedResults.Rd
@@ -34,6 +34,10 @@ if \code{test} is a \linkS4class{SummarizedExperiment} object.}
 
 \item{check.missing}{Logical scalar indicating whether rows should be checked for missing values (and if found, removed).}
 
+\item{allow.lost}{Logical scalar indicating whether to use lost markers in references where they are available.}
+
+\item{warn.lost}{Logical scalar indicating whether to emit a warning if markers from one reference in \code{trained} are \dQuote{lost} in other references.}
+
 \item{BNPARAM}{A \linkS4class{BiocNeighborParam} object specifying the algorithm to use for building nearest neighbor indices.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object specifying how parallelization should be performed, if any.}
@@ -62,8 +66,8 @@ The label from the results with the highest score for each cell is retained.
 Unlike \code{\link{combineCommonResults}}, this does not assume that each run of \code{\link{classifySingleR}} was performed using the same set of common genes, instead recomputing the scores for comparison across references.
 }
 \details{
-Here, the strategy is to performed classification separately within each reference, 
-then collating the results to choose the label with the highest score across references.
+Here, the strategy is to perform classification separately within each reference, 
+then collate the results to choose the label with the highest score across references.
 For a given cell in \code{test}, we extract its assigned label from \code{results} for each reference.
 We also retrieve the marker genes associated with that label and take the union of markers across all references.
 This defines a common feature space in which the score for each reference's assigned label is recomputed using \code{ref};
@@ -75,11 +79,23 @@ Obviously, \code{combineRecomputedResults} is slower as it does require recomput
 but the within-reference calls are faster as there are fewer genes in the union of markers for assigned labels
 (compared to the union of markers across all labels, as required by \code{\link{combineCommonResults}}),
 so it is likely that the net compute time should be lower.
-
-It is strongly recommended that the universe of genes be the same across all references.
-The intersection of genes across all \code{ref} and \code{test} is used when recomputing scores,
-and differences in the availability of genes between references may have unpredictable effects.
 }
+\section{Dealing with mismatching gene availabilities}{
+
+It is strongly recommended that the universe of genes be the same across all references in \code{trained}.
+If this is not the case, the intersection of genes across all \code{trained} will be used in the recomputation.
+This at least provides a common feature space for comparing correlations, 
+though differences in the availability of markers between references may have unpredictable effects on the results
+(and so a warning will be emitted by default, when when \code{warn.lost=TRUE}).
+
+That said, the intersection may be too string when dealing with many references with diverse feature annotations. 
+In such cases, we can set \code{allow.lost=TRUE} so that the recomputation for each reference will use all available markers in that reference.
+The idea here is to avoid penalizing all references by removing an informative marker when it is only absent in a single reference.
+We hope that the recomputed scores are still roughly comparable if the number of lost markers is relatively low,
+coupled with the use of ranks in the calculation of the Spearman-based scores to reduce the influence of individual markers.
+This is perhaps as reliable as one might imagine, so setting \code{allow.lost=TRUE} should be considered a last resort.
+}
+
 \examples{
 # Making up data.
 ref <- .mockRefData(nreps=8)

--- a/man/combineRecomputedResults.Rd
+++ b/man/combineRecomputedResults.Rd
@@ -11,6 +11,8 @@ combineRecomputedResults(
   quantile = 0.8,
   assay.type.test = "logcounts",
   check.missing = TRUE,
+  allow.lost = FALSE,
+  warn.lost = TRUE,
   BNPARAM = KmknnParam(),
   BPPARAM = SerialParam()
 )

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -51,11 +51,27 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// recompute_scores_with_na
+Rcpp::RObject recompute_scores_with_na(Rcpp::List Groups, Rcpp::RObject Exprs, Rcpp::IntegerMatrix Labels, Rcpp::List References, Rcpp::List Genes, double quantile);
+RcppExport SEXP _SingleR_recompute_scores_with_na(SEXP GroupsSEXP, SEXP ExprsSEXP, SEXP LabelsSEXP, SEXP ReferencesSEXP, SEXP GenesSEXP, SEXP quantileSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< Rcpp::List >::type Groups(GroupsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::RObject >::type Exprs(ExprsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerMatrix >::type Labels(LabelsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type References(ReferencesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type Genes(GenesSEXP);
+    Rcpp::traits::input_parameter< double >::type quantile(quantileSEXP);
+    rcpp_result_gen = Rcpp::wrap(recompute_scores_with_na(Groups, Exprs, Labels, References, Genes, quantile));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_SingleR_fine_tune_label_de", (DL_FUNC) &_SingleR_fine_tune_label_de, 6},
     {"_SingleR_fine_tune_label_sd", (DL_FUNC) &_SingleR_fine_tune_label_sd, 7},
     {"_SingleR_recompute_scores", (DL_FUNC) &_SingleR_recompute_scores, 6},
+    {"_SingleR_recompute_scores_with_na", (DL_FUNC) &_SingleR_recompute_scores_with_na, 6},
     {NULL, NULL, 0}
 };
 

--- a/src/compute_scores.h
+++ b/src/compute_scores.h
@@ -26,7 +26,7 @@ inline double correlations_to_scores (std::vector<double>& all_correlations, dou
         std::nth_element(all_correlations.begin(), all_correlations.begin()+qn, all_correlations.end());
         const double rightval=all_correlations[qn];
 
-        // Do NOT be tempted to do the second nth_element with the end at end()+qn;
+        // Do NOT be tempted to do the second nth_element with the end at begin()+qn;
         // this does not handle ties properly.
         std::nth_element(all_correlations.begin(), all_correlations.begin()+qn-1, all_correlations.end());
         const double leftval=all_correlations[qn-1];

--- a/src/scaled_ranks.h
+++ b/src/scaled_ranks.h
@@ -28,7 +28,12 @@ void scaled_ranks(IT start, const std::vector<int>& chosen, ranked_vector& colle
     // Computing tied ranks. 
     size_t cur_rank=0;
     auto cIt=collected.begin();
-    outgoing.resize(slen, na_aware ? R_NaReal : 0);
+    if (na_aware) {
+        outgoing.clear();
+        outgoing.resize(slen, R_NaReal);
+    } else {
+        outgoing.resize(slen);
+    }
 
     while (cIt!=collected.end()) {
         auto copy=cIt;
@@ -51,7 +56,7 @@ void scaled_ranks(IT start, const std::vector<int>& chosen, ranked_vector& colle
 
     // Mean-adjusting and converting to cosine values.
     double sum_squares=0;
-    const double center_rank=static_cast<double>(slen-1)/2;
+    const double center_rank=static_cast<double>(collected.size() - 1)/2; // use collected.size(), not slen, to account for NA's.
     for (auto& o : outgoing) {
         if (na_aware && ISNA(o)) {
             continue;


### PR DESCRIPTION
The idea is that `combineRecomputedResults()` can support results generated from references with non-identical feature sets. The results will be as reliable as one might imagine, but at least the loss of a few genes here and there won't nix the entire effort.