### PR TITLE
Expand plotScoreHeatmap annotation colors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SingleR
 Title: Reference-Based Single-Cell RNA-Seq Annotation
-Version: 1.5.7
-Date: 2021-05-13
+Version: 1.5.8
+Date: 2021-05-17
 Authors@R: c(person("Dvir", "Aran", email="dvir.aran@ucsf.edu", role=c("aut", "cph")),
     person("Aaron", "Lun", email="infinite.monkeys.with.keyboards@gmail.com", role=c("ctb", "cre")),
     person("Daniel", "Bunis", role="ctb"),

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -529,15 +529,20 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
 }
 
 .make_heatmap_colors_discrete <- function(show.pruned) {
-    # Creates a default vector of colors with 24*10 (overkill) options.
+    # Creates a default vector of colors with 40*10 (overkill) options.
     annotation.colors <- rep(
-        # DittoSeq-v0.2.10 Colors (based on Okabe-Ito colors)
+        # DittoSeq-v1.4 Colors (based on Okabe-Ito colors)
         c(
-            "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2",
-            "#D55E00", "#CC79A7", "#666666", "#AD7700", "#1C91D4",
-            "#007756", "#D5C711", "#005685", "#A04700", "#B14380",
-            "#4D4D4D", "#FFBE2D", "#80C7EF", "#00F6B3", "#F4EB71",
-            "#06A5FF", "#FF8320", "#D99BBD", "#8C8C8C"),
+            "#E69F00", "#56B4E9", "#009E73", "#F0E442",
+            "#0072B2", "#D55E00", "#CC79A7", "#666666",
+            "#AD7700", "#1C91D4", "#007756", "#D5C711",
+            "#005685", "#A04700", "#B14380", "#4D4D4D",
+            "#FFBE2D", "#80C7EF", "#00F6B3", "#F4EB71",
+            "#06A5FF", "#FF8320", "#D99BBD", "#8C8C8C",
+            "#FFCB57", "#9AD2F2", "#2CFFC6", "#F6EF8E",
+            "#38B7FF", "#FF9B4D", "#E0AFCA", "#A3A3A3",
+            "#8A5F00", "#1674A9", "#005F45", "#AA9F0D",
+            "#00446B", "#803800", "#8D3666", "#3D3D3D"),
         10)
     if (show.pruned) {
         annotation.colors <- c("white", annotation.colors)


### PR DESCRIPTION
Specifically, pulls the current `dittoSeq::dittoColors()` and adds 16 more discrete colors for plotScoreHeatmap annotations than are currently there.