### PR TITLE
Fix color control of plotScoreHeatmap when 'normalize=TRUE'

### DIFF
--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -29,14 +29,16 @@
 #' Contents should be the reference-labels in the order you would like them to appear, from top-to-bottom.
 #' For combined results, include labels for all plots in a single vector and labels relevant to each plot will be extracted.
 #' @param na.color String specifying the color for non-calculated scores of combined \code{results}.
-#' @param color NA or a vector of colors passed to the \code{\link[pheatmap]{pheatmap}} input of the same name.
-#' When left as NA, SingleR defaults are used.
-#' @param breaks,legend_breaks,legend_labels NA or vectors of values or labels passed to the \code{\link[pheatmap]{pheatmap}} input of the same name.
-#' By default SingleR uses these inputs: \itemize{
-#' \item when \code{normalize=FALSE}), to ensure use of evenly diverging color legend extents and labels.
-#' \item when \code{normalize=TRUE), to relabel only legend extents as "Lower" and "Higher" as actual normalized values have little meaning.
-#' \item always when NA values exist in the targeted scores, even if you set them, to display the \code{na.color} in the legend.
-#' }
+#' This will always be displayed in the legend if any \code{NA} values are present in the scores.
+#' @param color Character vector of colors passed to \code{\link[pheatmap]{pheatmap}}.
+#' If \code{NA} and \code{normalize=TRUE}, the viridis color scheme is used by default;
+#' while if \code{normalize=FALSE}, a default red-blue color scheme is chosen that should be symmetric around zero (see \code{breaks}).
+#' @param breaks Numeric vector to map scores to colors, see the argument of the same name in \code{\link[pheatmap]{pheatmap}}. 
+#' If \code{NA}, this defaults to a sequence from 0 to 1 when \code{normalize=TRUE}, 
+#' or a sequence from -T to T where T is the largest absolute score when \code{normalize=FALSE}.
+#' @param legend_breaks,legend_labels Arguments passed to \code{\link[pheatmap]{pheatmap}} to label the legend.
+#' If \code{NA}, only the legend extremes are labelled by default;
+#' and when \code{normalize=TRUE}, the legend extremes are only labelled as \dQuote{Lower} and \dQuote{Higher}, as actual normalized values have little meaning.
 #' @param annotation_col,cluster_cols,show_colnames,silent,...
 #' Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.
 #' @param grid.vars A named list of extra variables to pass to \code{\link[gridExtra]{grid.arrange}},
@@ -368,7 +370,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
         abs.max <- max(abs(range(scores, na.rm = TRUE)))
         breaks.len <- length(args$color)+1
         default_breaks <- seq(-abs.max, abs.max, length.out = breaks.len)
-        default_legend_breaks <- c(-abs.max, abs.max, length.out = 3)
+        default_legend_breaks <- c(-abs.max, abs.max)
         default_legend_labels <- round(default_legend_breaks, 3)
     }
     args$breaks <- default_if_NA(breaks, default_breaks)

--- a/R/plotScoreHeatmap.R
+++ b/R/plotScoreHeatmap.R
@@ -29,7 +29,9 @@
 #' Contents should be the reference-labels in the order you would like them to appear, from top-to-bottom.
 #' For combined results, include labels for all plots in a single vector and labels relevant to each plot will be extracted.
 #' @param na.color String specifying the color for non-calculated scores of combined \code{results}.
-#' @param annotation_col,cluster_cols,show_colnames,color,silent,...
+#' @param color NA or a vector of colors passed to the \code{\link[pheatmap]{pheatmap}} input of the same name.
+#' When left as NA, SingleR defaults are used.
+#' @param annotation_col,cluster_cols,show_colnames,silent,...
 #' Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.
 #' @param grid.vars A named list of extra variables to pass to \code{\link[gridExtra]{grid.arrange}},
 #' used to arrange the multiple plots generated when \code{scores.use} is of length greater than 1.
@@ -187,7 +189,7 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
     scores.use = NULL, calls.use = 0, na.color = "gray30",
     cluster_cols = FALSE,
     annotation_col = NULL, show_colnames = FALSE,
-    color = grDevices::colorRampPalette(c("#D1147E", "white", "#00A44B"))(100),
+    color = NA,
     silent = FALSE, ..., grid.vars = list())
 {
     results <- .ensure_named(results)
@@ -337,8 +339,9 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
 
     # Add scores & score colors
     ## Set score colors and legend display
+    default_color <- grDevices::colorRampPalette(c("#D1147E", "white", "#00A44B"))(100)
     if (normalize && ncol(scores) > 1) {
-        color <- viridis::viridis(100)
+        default_color <- viridis::viridis(100)
         args$breaks <- seq(0, 1, length.out = 101)
         args$legend_breaks <- c(0,1)
         args$legend_labels <- c("Lower", "Higher")
@@ -349,7 +352,11 @@ plotScoreHeatmap <- function(results, cells.use = NULL, labels.use = NULL,
         args$legend_breaks <- c(-abs.max, abs.max, length.out = 3)
         args$legend_labels <- round(args$legend_breaks, 3)
     }
-    args$color <- color
+    args$color <- if (identical(color, NA)) {
+        default_color
+    } else {
+        color
+    }
 
     # Replace NAs and add na.color
     if (any(is.na(scores))) {

--- a/man/plotScoreHeatmap.Rd
+++ b/man/plotScoreHeatmap.Rd
@@ -19,10 +19,13 @@ plotScoreHeatmap(
   scores.use = NULL,
   calls.use = 0,
   na.color = "gray30",
+  color = NA,
+  breaks = NA,
+  legend_breaks = NA,
+  legend_labels = NA,
   cluster_cols = FALSE,
   annotation_col = NULL,
   show_colnames = FALSE,
-  color = (grDevices::colorRampPalette(c("#D1147E", "white", "#00A44B")))(100),
   silent = FALSE,
   ...,
   grid.vars = list()
@@ -68,9 +71,22 @@ This is only relevant for combined results, see Details.}
 for use in the annotation bar when \code{show.labels=TRUE}.
 This is only relevant for combined results, see Details.}
 
-\item{na.color}{String specifying the color for non-calculated scores of combined \code{results}.}
+\item{na.color}{String specifying the color for non-calculated scores of combined \code{results}.
+This will always be displayed in the legend if any \code{NA} values are present in the scores.}
 
-\item{annotation_col, cluster_cols, show_colnames, color, silent, ...}{Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.}
+\item{color}{Character vector of colors passed to \code{\link[pheatmap]{pheatmap}}.
+If \code{NA} and \code{normalize=TRUE}, the viridis color scheme is used by default;
+while if \code{normalize=FALSE}, a default red-blue color scheme is chosen that should be symmetric around zero (see \code{breaks}).}
+
+\item{breaks}{Numeric vector to map scores to colors, see the argument of the same name in \code{\link[pheatmap]{pheatmap}}. 
+If \code{NA}, this defaults to a sequence from 0 to 1 when \code{normalize=TRUE}, 
+or a sequence from -T to T where T is the largest absolute score when \code{normalize=FALSE}.}
+
+\item{legend_breaks, legend_labels}{Arguments passed to \code{\link[pheatmap]{pheatmap}} to label the legend.
+If \code{NA}, only the legend extremes are labelled by default;
+and when \code{normalize=TRUE}, the legend extremes are only labelled as \dQuote{Lower} and \dQuote{Higher}, as actual normalized values have little meaning.}
+
+\item{annotation_col, cluster_cols, show_colnames, silent, ...}{Additional parameters for heatmap control passed to \code{\link[pheatmap]{pheatmap}}.}
 
 \item{grid.vars}{A named list of extra variables to pass to \code{\link[gridExtra]{grid.arrange}},
 used to arrange the multiple plots generated when \code{scores.use} is of length greater than 1.}

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -63,10 +63,15 @@ test_that("heatmap - can pass excess pheatmap::pheatmap parameters through plotS
         5)
 })
 
-test_that("heatmap scores color can be adjusted when 'normalize = FALSE'", {
+test_that("heatmap scores color can be adjusted, regardless of 'normalize' value", {
     expect_equal(
         plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
             normalize = FALSE,
+            color = colorRampPalette(c("red", "blue"))(33))$color,
+        colorRampPalette(c("red", "blue"))(33))
+    expect_equal(
+        plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
+            normalize = TRUE,
             color = colorRampPalette(c("red", "blue"))(33))$color,
         colorRampPalette(c("red", "blue"))(33))
 })

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -93,7 +93,7 @@ test_that("heatmap allows users to adjust breaks, legend_breaks, legend_labels",
         legend_labels = c("manually", "set", "labels"))
     expect_equal(non_norm_args$breaks, seq(-5, 5, length.out = 34))
     expect_equal(non_norm_args$legend_breaks, c(-5, 0, 5))
-    expect_equal(non_norm_args$legened_labels, c("manually", "set", "labels"))
+    expect_equal(non_norm_args$legend_labels, c("manually", "set", "labels"))
     norm_args <- plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
         normalize = TRUE,
         color = colorRampPalette(c("red", "blue"))(33),
@@ -102,7 +102,7 @@ test_that("heatmap allows users to adjust breaks, legend_breaks, legend_labels",
         legend_labels = c("manually", "set", "labels"))
     expect_equal(norm_args$breaks, seq(-5, 5, length.out = 34))
     expect_equal(norm_args$legend_breaks, c(-5, 0, 5))
-    expect_equal(norm_args$legened_labels, c("manually", "set", "labels"))
+    expect_equal(norm_args$legend_labels, c("manually", "set", "labels"))
 })
 
 test_that("heatmap is adjusted properly when 'labels.use' yields 1 or 0 labels", {

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -81,26 +81,26 @@ test_that("heatmap allows users to adjust breaks, legend_breaks, legend_labels",
         plotScoreHeatmap(results = pred, silent = TRUE,
             normalize = FALSE,
             color = colorRampPalette(c("red", "blue"))(33),
-            breaks = seq(-5, 5, 34),
+            breaks = seq(-5, 5, length.out = 34),
             legend_breaks = c(-5, 0, 5),
             legend_labels = c("manually", "set", "labels")),
         "pheatmap")
     non_norm_args <- plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
         normalize = FALSE,
         color = colorRampPalette(c("red", "blue"))(33),
-        breaks = seq(-5, 5, 34),
+        breaks = seq(-5, 5, length.out = 34),
         legend_breaks = c(-5, 0, 5),
         legend_labels = c("manually", "set", "labels"))
-    expect_equal(non_norm_args$breaks, seq(-5, 5, 34))
+    expect_equal(non_norm_args$breaks, seq(-5, 5, length.out = 34))
     expect_equal(non_norm_args$legend_breaks, c(-5, 0, 5))
     expect_equal(non_norm_args$legened_labels, c("manually", "set", "labels"))
     norm_args <- plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
         normalize = TRUE,
         color = colorRampPalette(c("red", "blue"))(33),
-        breaks = seq(-5, 5, 34),
+        breaks = seq(-5, 5, length.out = 34),
         legend_breaks = c(-5, 0, 5),
         legend_labels = c("manually", "set", "labels"))
-    expect_equal(norm_args$breaks, seq(-5, 5, 34))
+    expect_equal(norm_args$breaks, seq(-5, 5, length.out = 34))
     expect_equal(norm_args$legend_breaks, c(-5, 0, 5))
     expect_equal(norm_args$legened_labels, c("manually", "set", "labels"))
 })

--- a/tests/testthat/test-heatmap.R
+++ b/tests/testthat/test-heatmap.R
@@ -76,6 +76,35 @@ test_that("heatmap scores color can be adjusted, regardless of 'normalize' value
         colorRampPalette(c("red", "blue"))(33))
 })
 
+test_that("heatmap allows users to adjust breaks, legend_breaks, legend_labels", {
+    expect_s3_class(
+        plotScoreHeatmap(results = pred, silent = TRUE,
+            normalize = FALSE,
+            color = colorRampPalette(c("red", "blue"))(33),
+            breaks = seq(-5, 5, 34),
+            legend_breaks = c(-5, 0, 5),
+            legend_labels = c("manually", "set", "labels")),
+        "pheatmap")
+    non_norm_args <- plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
+        normalize = FALSE,
+        color = colorRampPalette(c("red", "blue"))(33),
+        breaks = seq(-5, 5, 34),
+        legend_breaks = c(-5, 0, 5),
+        legend_labels = c("manually", "set", "labels"))
+    expect_equal(non_norm_args$breaks, seq(-5, 5, 34))
+    expect_equal(non_norm_args$legend_breaks, c(-5, 0, 5))
+    expect_equal(non_norm_args$legened_labels, c("manually", "set", "labels"))
+    norm_args <- plotScoreHeatmap(results = pred, silent = TRUE, return.data = TRUE,
+        normalize = TRUE,
+        color = colorRampPalette(c("red", "blue"))(33),
+        breaks = seq(-5, 5, 34),
+        legend_breaks = c(-5, 0, 5),
+        legend_labels = c("manually", "set", "labels"))
+    expect_equal(norm_args$breaks, seq(-5, 5, 34))
+    expect_equal(norm_args$legend_breaks, c(-5, 0, 5))
+    expect_equal(norm_args$legened_labels, c("manually", "set", "labels"))
+})
+
 test_that("heatmap is adjusted properly when 'labels.use' yields 1 or 0 labels", {
     # Should give message but still output plot
     expect_warning(plotScoreHeatmap(results = pred,


### PR DESCRIPTION
Per #197

Bug Fix: This PR ensures that when users supply their own `color` map to the `plotScoreHeatmap()` function, it will be used regardless of whether `normalize` was set to `TRUE`.

New Feature: Also gives users expanded control over their legend by newly allowing override of SingleR's default strategies for filling the pheatmap inputs `breaks`, `legend_breaks`, and `legend_labels`.

ToDo:
- [x] add test
- [x] double-check the other pheatmap inputs for similar overrides, and fix if makes sense
- [x] roxygenize