### PR TITLE
fix: move scrapper to "Imports" packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     stats,
     utils,
     Rcpp,
+    scrapper,
     beachmat (>= 2.25.1)
 LinkingTo:
     Rcpp,
@@ -37,7 +38,6 @@ Suggests:
     BiocGenerics,
     SingleCellExperiment,
     scuttle,
-    scrapper,
     scRNAseq,
     ggplot2,
     pheatmap,


### PR DESCRIPTION
Solves https://github.com/SingleR-inc/SingleR/issues/298.
At least SingleR() with `clusters` option requires `scrapper`, which is a common usage of SingleR for me.

This will make SingleR workflow smoother, without the hassle to install `scrapper` manually.